### PR TITLE
feat: melhora registros e fechamento PDF com filtros operacionais e layout auditável

### DIFF
--- a/Master/src/assets/js/components/date-picker-dashboard.js
+++ b/Master/src/assets/js/components/date-picker-dashboard.js
@@ -70,6 +70,10 @@
         start = new Date(y, m, d - 30);
         end = new Date(y, m, d);
         break;
+      case "ultimos90":
+        start = new Date(y, m, d - 90);
+        end = new Date(y, m, d);
+        break;
       default:
         start = new Date(y, m, d);
         end = new Date(y, m, d);
@@ -199,8 +203,8 @@
       const r = getPresetRange(preset);
       selectedStart = r.start;
       selectedEnd = r.end;
-      // Presets que definem intervalo (quinzena, semana, mês, ultimos30) devem usar modo "periodo" para Aplicar retornar start e end corretos
-      if (preset === "quinzena" || preset === "quinzena-ant" || preset === "semana" || preset === "mes" || preset === "ultimos30") {
+      // Presets que definem intervalo (quinzena, semana, mês, ultimos30/90) devem usar modo "periodo" para Aplicar retornar start e end corretos
+      if (preset === "quinzena" || preset === "quinzena-ant" || preset === "semana" || preset === "mes" || preset === "ultimos30" || preset === "ultimos90") {
         filterMode = "periodo";
         isSelectingStart = false;
         var modeSelect = document.getElementById(prefix + "-filter-mode");
@@ -401,6 +405,7 @@
             '<button type="button" class="btn btn-outline-secondary btn-sm text-start dp-preset" data-preset="quinzena-ant">Quinzena anterior</button>' +
             '<button type="button" class="btn btn-outline-secondary btn-sm text-start dp-preset" data-preset="mes">Mês</button>' +
             '<button type="button" class="btn btn-outline-secondary btn-sm text-start dp-preset" data-preset="ultimos30">Hoje - 30 dias</button>' +
+            '<button type="button" class="btn btn-outline-secondary btn-sm text-start dp-preset" data-preset="ultimos90">Hoje - 90 dias</button>' +
           '</div>' +
         '</details>' +
       '</div>' +

--- a/Master/src/assets/js/components/date-picker-dashboard.js
+++ b/Master/src/assets/js/components/date-picker-dashboard.js
@@ -70,8 +70,8 @@
         start = new Date(y, m, d - 30);
         end = new Date(y, m, d);
         break;
-      case "ultimos90":
-        start = new Date(y, m, d - 90);
+      case "ultimos45":
+        start = new Date(y, m, d - 45);
         end = new Date(y, m, d);
         break;
       default:
@@ -203,8 +203,8 @@
       const r = getPresetRange(preset);
       selectedStart = r.start;
       selectedEnd = r.end;
-      // Presets que definem intervalo (quinzena, semana, mês, ultimos30/90) devem usar modo "periodo" para Aplicar retornar start e end corretos
-      if (preset === "quinzena" || preset === "quinzena-ant" || preset === "semana" || preset === "mes" || preset === "ultimos30" || preset === "ultimos90") {
+      // Presets que definem intervalo (quinzena, semana, mês, ultimos30/45) devem usar modo "periodo" para Aplicar retornar start e end corretos
+      if (preset === "quinzena" || preset === "quinzena-ant" || preset === "semana" || preset === "mes" || preset === "ultimos30" || preset === "ultimos45") {
         filterMode = "periodo";
         isSelectingStart = false;
         var modeSelect = document.getElementById(prefix + "-filter-mode");
@@ -405,7 +405,7 @@
             '<button type="button" class="btn btn-outline-secondary btn-sm text-start dp-preset" data-preset="quinzena-ant">Quinzena anterior</button>' +
             '<button type="button" class="btn btn-outline-secondary btn-sm text-start dp-preset" data-preset="mes">Mês</button>' +
             '<button type="button" class="btn btn-outline-secondary btn-sm text-start dp-preset" data-preset="ultimos30">Hoje - 30 dias</button>' +
-            '<button type="button" class="btn btn-outline-secondary btn-sm text-start dp-preset" data-preset="ultimos90">Hoje - 90 dias</button>' +
+            '<button type="button" class="btn btn-outline-secondary btn-sm text-start dp-preset" data-preset="ultimos45">Hoje - 45 dias</button>' +
           '</div>' +
         '</details>' +
       '</div>' +

--- a/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
@@ -29,8 +29,21 @@
     if (params?.ate)        q.set("ate", params.ate);
     if (params?.base)       q.set("base", params.base);
     if (params?.entregador) q.set("entregador", params.entregador);
-    if (params?.status)     q.set("status", params.status);
-    if (params?.servico)    q.set("servico", params.servico);
+    if (Array.isArray(params?.status)) {
+      params.status.forEach(v => { if (v != null && String(v).trim()) q.append("status", String(v).trim()); });
+    } else if (params?.status) {
+      q.set("status", params.status);
+    }
+    if (Array.isArray(params?.servico)) {
+      params.servico.forEach(v => { if (v != null && String(v).trim()) q.append("servico", String(v).trim()); });
+    } else if (params?.servico) {
+      q.set("servico", params.servico);
+    }
+    if (Array.isArray(params?.acao)) {
+      params.acao.forEach(v => { if (v != null && String(v).trim()) q.append("acao", String(v).trim()); });
+    } else if (params?.acao) {
+      q.set("acao", params.acao);
+    }
     if (params?.somente_g)  q.set("somente_g", "true");
     if (params?.localizar)  q.set("localizar", params.localizar);
     if (params?.codigo)     q.set("codigo", params.codigo);

--- a/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
@@ -24,6 +24,40 @@
   const ESPACO_SECAO = 10;
   const ESPACO_LINHA = 6;
   const COR_GRADIENTE_SISTEMA = [74, 46, 127];
+  const STATUS_LABELS = {
+    PENDENTE: "PENDENTE",
+    GERADO: "GERADO",
+    REAJUSTADO: "REAJUSTADO",
+    FECHADO: "GERADO",
+  };
+
+  function toIsoMonth(ymd) {
+    const [y, m] = String(ymd || "").split("-");
+    if (!y || !m) return "000000";
+    return `${y}${m}`;
+  }
+
+  function padLeft(v, n) {
+    const s = String(v == null ? "" : v);
+    return s.padStart(n, "0");
+  }
+
+  function buildFechamentoCode(fech, entNome) {
+    const id = Number(fech?.id_fechamento || 0);
+    const periodoKey = toIsoMonth(fech?.periodo_fim || fech?.periodo_inicio);
+    const executorTag = String(entNome || fech?.username_entregador || "MOTOBOY")
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[^a-zA-Z0-9]+/g, "")
+      .toUpperCase()
+      .slice(0, 12) || "MOTOBOY";
+    return `FEC-${periodoKey}-${executorTag}-${padLeft(id, 6)}`;
+  }
+
+  function normalizeStatus(status) {
+    const key = String(status || "PENDENTE").toUpperCase();
+    return STATUS_LABELS[key] || key;
+  }
 
   function linhaHorizontal(doc, y, xIni, xFim) {
     doc.setDrawColor(180, 180, 180);
@@ -42,6 +76,9 @@
     const doc = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
     const pageW = doc.internal.pageSize.getWidth();
 
+    const statusFechamento = normalizeStatus(fech?.status);
+    const entNome = fech.username_entregador || fech.entregador_nome || "Motoboy";
+    const fechamentoCode = buildFechamentoCode(fech, entNome);
     let y = 15;
 
     doc.setFillColor(COR_GRADIENTE_SISTEMA[0], COR_GRADIENTE_SISTEMA[1], COR_GRADIENTE_SISTEMA[2]);
@@ -49,7 +86,7 @@
     doc.setTextColor(255, 255, 255);
     doc.setFontSize(18);
     doc.setFont("helvetica", "bold");
-    doc.text("FECHAMENTO DE ENTREGAS", 105, y + 4, { align: "center" });
+    doc.text("FECHAMENTO DE ENTREGAS — MOTOBOY", 105, y + 4, { align: "center" });
     doc.setFont("helvetica", "normal");
     doc.setTextColor(0, 0, 0);
     y = 28;
@@ -58,12 +95,25 @@
 
     // 1.2 Informações iniciais (linhas separadas, espaçamento confortável)
     doc.setFontSize(10);
-    doc.text("Entregador: " + (fech.username_entregador || fech.entregador_nome || "—"), MARGEM, y);
+    doc.text("Código do fechamento: " + fechamentoCode, MARGEM, y);
     y += ESPACO_LINHA;
+    doc.text("Status: " + statusFechamento, MARGEM, y);
+    y += ESPACO_LINHA;
+    doc.text("Entregador: " + entNome, MARGEM, y);
+    y += ESPACO_SECAO;
     doc.text("Período: " + fmtData(fech.periodo_inicio) + " a " + fmtData(fech.periodo_fim), MARGEM, y);
     y += ESPACO_LINHA;
-    doc.text("Data de geração: " + new Date().toLocaleDateString("pt-BR"), MARGEM, y);
+    doc.text("Data de geração: " + new Date().toLocaleString("pt-BR"), MARGEM, y);
     y += ESPACO_SECAO;
+
+    const sumShopee = itensDiarios.reduce((s, r) => s + (r.shopee?.qtde ?? 0), 0);
+    const sumFlex = itensDiarios.reduce((s, r) => s + (r.flex?.qtde ?? 0), 0);
+    const sumAvulso = itensDiarios.reduce((s, r) => s + (r.avulso?.qtde ?? 0), 0);
+    const totalFeitos = sumShopee + sumFlex + sumAvulso;
+    const totalCancelados = itensDiarios.reduce((s, r) => s + Number(r.total_cancelado ?? 0), 0);
+    const valorFeitos = itensDiarios.reduce((s, r) => s + Number(r.valor_feitos ?? 0), 0);
+    const valorCancelados = itensDiarios.reduce((s, r) => s + Number(r.valor_cancelados ?? 0), 0);
+    const totalAjustes = (fech.valor_adicao || 0) - (fech.valor_subtracao || 0);
 
     // 1.3 Pacotes Grandes (G) — totalizador e lista
     const pacotesGNorm = (pacotesG || []).map((p) => ({
@@ -78,6 +128,31 @@
       return !s.includes("shopee") && !s.includes("mercado");
     }).length;
     const totalG = pacotesGNorm.length;
+
+    doc.setFontSize(11);
+    doc.setFont("helvetica", "bold");
+    doc.text("Resumo do fechamento", MARGEM, y);
+    doc.setFont("helvetica", "normal");
+    y += ESPACO_LINHA;
+    doc.setFontSize(10);
+    doc.text(`Total feitos: ${totalFeitos}`, MARGEM, y);
+    y += ESPACO_LINHA;
+    doc.text(`Cancelados: ${totalCancelados}`, MARGEM, y);
+    y += ESPACO_LINHA;
+    doc.text(`Pacotes grandes: ${totalG}`, MARGEM, y);
+    y += ESPACO_LINHA;
+    doc.text(`Valor feitos: ${fmt(valorFeitos)}`, MARGEM, y);
+    y += ESPACO_LINHA;
+    doc.text(`Valor cancelados: ${fmt(valorCancelados)}`, MARGEM, y);
+    y += ESPACO_LINHA;
+    doc.text(`Ajustes: ${fmt(totalAjustes)}`, MARGEM, y);
+    y += ESPACO_LINHA + 1;
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(12);
+    doc.text(`TOTAL A PAGAR: ${fmt(fech.valor_final)}`, MARGEM, y);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(10);
+    y += ESPACO_SECAO;
 
     doc.setFontSize(11);
     doc.setFont("helvetica", "bold");
@@ -119,14 +194,23 @@
     }
 
     // 2. TABELA DIÁRIA — cabeçalho destacado, espaçamento confortável, valores R$ com 2 decimais
-    const colsDiaria = ["Data", "Shopee", "Mercado Livre", "Avulso", "Total", "Valor do dia"];
+    doc.setFontSize(11);
+    doc.setFont("helvetica", "bold");
+    doc.text("Detalhamento por dia", MARGEM, y);
+    doc.setFont("helvetica", "normal");
+    y += ESPACO_LINHA;
+    const colsDiaria = ["Data", "Flex", "Shopee", "Avulso", "G", "Total Feitos", "Cancelados", "Valor Feitos", "Valor Cancelados", "Valor Total"];
     const rowsDiaria = itensDiarios.map((r) => [
       fmtData(r.data),
-      r.shopee?.qtde ?? 0,
       r.flex?.qtde ?? 0,
+      r.shopee?.qtde ?? 0,
       r.avulso?.qtde ?? 0,
-      (r.shopee?.qtde ?? 0) + (r.flex?.qtde ?? 0) + (r.avulso?.qtde ?? 0),
-      fmt(r.total_dia),
+      r.g_total ?? 0,
+      r.total_feitos ?? ((r.shopee?.qtde ?? 0) + (r.flex?.qtde ?? 0) + (r.avulso?.qtde ?? 0)),
+      r.total_cancelado ?? 0,
+      fmt(r.valor_feitos),
+      fmt(r.valor_cancelados),
+      fmt(r.valor_total != null ? r.valor_total : r.total_dia),
     ]);
     doc.autoTable({
       startY: y,
@@ -134,35 +218,51 @@
       body: rowsDiaria,
       theme: "grid",
       headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
-      columnStyles: { 5: { cellWidth: "auto" } },
+      columnStyles: {
+        1: { halign: "right" },
+        2: { halign: "right" },
+        3: { halign: "right" },
+        4: { halign: "right" },
+        5: { halign: "right" },
+        6: { halign: "right" },
+        7: { halign: "right" },
+        8: { halign: "right" },
+        9: { halign: "right" },
+      },
       margin: { left: MARGEM },
       tableLineColor: [200, 200, 200],
       cellPadding: 3,
     });
     y = doc.lastAutoTable.finalY + ESPACO_SECAO;
 
-    // 3. BLOCO "RESUMO DAS SAÍDAS" — linhas separadas, espaçamento antes/depois
-    const sumShopee = itensDiarios.reduce((s, r) => s + (r.shopee?.qtde ?? 0), 0);
-    const sumFlex = itensDiarios.reduce((s, r) => s + (r.flex?.qtde ?? 0), 0);
-    const sumAvulso = itensDiarios.reduce((s, r) => s + (r.avulso?.qtde ?? 0), 0);
-    const sumTotal = sumShopee + sumFlex + sumAvulso;
-    y += 4;
+    // 3. PACOTES G
     doc.setFontSize(11);
     doc.setFont("helvetica", "bold");
-    doc.text("Resumo das Saídas", MARGEM, y);
+    doc.text("Pacotes Grandes", MARGEM, y);
     doc.setFont("helvetica", "normal");
     y += ESPACO_LINHA;
-    doc.setFontSize(10);
-    doc.text("Shopee: " + sumShopee, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Mercado Livre: " + sumFlex, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Avulso: " + sumAvulso, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Total: " + sumTotal, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Valor Base: " + fmt(fech.valor_base), MARGEM, y);
-    y += ESPACO_SECAO + 2;
+    if (!pacotesGNorm.length) {
+      doc.setFontSize(10);
+      doc.text("Pacotes Grandes: nenhum pacote grande no período.", MARGEM, y);
+      y += ESPACO_SECAO;
+    } else {
+      doc.autoTable({
+        startY: y,
+        head: [["Serviço", "Quantidade G"]],
+        body: [
+          ["Shopee", totalGShopee],
+          ["Flex", totalGMercado],
+          ["Avulso", totalGAvulso],
+          ["Total", totalG],
+        ],
+        theme: "grid",
+        headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
+        columnStyles: { 1: { halign: "right" } },
+        margin: { left: MARGEM },
+        styles: { fontSize: 9 },
+      });
+      y = doc.lastAutoTable.finalY + ESPACO_SECAO;
+    }
 
     // 4. TABELA DE AJUSTES — cabeçalho destacado; se vazio: mensagem
     doc.setFontSize(11);
@@ -191,7 +291,27 @@
       y += ESPACO_SECAO;
     }
 
-    // 5. BLOCO "RESUMO FINANCEIRO" — linha antes; TOTAL A PAGAR em destaque
+    // 5. Critério de cálculo
+    doc.setFontSize(11);
+    doc.setFont("helvetica", "bold");
+    doc.text("Critério de cálculo", MARGEM, y);
+    doc.setFont("helvetica", "normal");
+    y += ESPACO_LINHA;
+    doc.setFontSize(9);
+    const criterio = [
+      "• Entregas concluídas são consideradas no valor de pagamento.",
+      "• Entregas canceladas são exibidas separadamente para conferência.",
+      "• Pacotes grandes são identificados pela coluna G.",
+      "• Ajustes manuais, quando existirem, são somados/subtraídos do valor final.",
+      "• O Total a pagar representa o valor final calculado para o período.",
+    ];
+    criterio.forEach((linha) => {
+      doc.text(linha, MARGEM, y);
+      y += 4.5;
+    });
+    y += 4;
+
+    // 6. BLOCO "RESUMO FINANCEIRO" — linha antes; TOTAL A PAGAR em destaque
     linhaHorizontal(doc, y, MARGEM, pageW - MARGEM);
     y += 6;
     doc.setFontSize(11);
@@ -200,10 +320,15 @@
     doc.setFont("helvetica", "normal");
     y += ESPACO_LINHA;
     doc.setFontSize(10);
-    doc.text("Valor Base (Saídas): " + fmt(fech.valor_base), MARGEM, y);
+    doc.text("Valor feitos: " + fmt(valorFeitos), MARGEM, y);
     y += ESPACO_LINHA;
-    const totalAjustes = (fech.valor_adicao || 0) - (fech.valor_subtracao || 0);
-    doc.text("Total Ajustes: " + fmt(totalAjustes), MARGEM, y);
+    doc.text("Valor cancelados: " + fmt(valorCancelados), MARGEM, y);
+    y += ESPACO_LINHA;
+    doc.text("Valor base: " + fmt(fech.valor_base), MARGEM, y);
+    y += ESPACO_LINHA;
+    doc.text("Ajustes manuais: " + fmt(totalAjustes), MARGEM, y);
+    y += ESPACO_LINHA;
+    doc.text("Adicional pacote grande: " + fmt(0), MARGEM, y);
     y += ESPACO_LINHA + 2;
     doc.setFontSize(12);
     doc.setFont("helvetica", "bold");
@@ -211,11 +336,14 @@
     doc.setFont("helvetica", "normal");
     y += 12;
 
-    // Rodapé (conteúdo já ajustado — não alterar)
+    // Rodapé de validação digital
     const ano = new Date().getFullYear();
-    doc.setFontSize(10);
+    doc.setFontSize(8.5);
     doc.setTextColor(80);
-    doc.text(`${ano} © TrackingSaídas.`, 105, doc.internal.pageSize.height - 10, { align: "center" });
+    const footerY = doc.internal.pageSize.height - 16;
+    doc.text("Documento gerado digitalmente pelo sistema.", 105, footerY, { align: "center" });
+    doc.text(`Código do fechamento: ${fechamentoCode} · Status: ${statusFechamento}`, 105, footerY + 4, { align: "center" });
+    doc.text(`Data de geração: ${new Date().toLocaleString("pt-BR")} · ${ano} © TrackingSaídas.`, 105, footerY + 8, { align: "center" });
     doc.save(nomeArq);
   }
 
@@ -240,7 +368,8 @@
       const ddIni = dIni.length >= 3 ? dIni[2] : "01";
       const ddFim = dFim.length >= 3 ? dFim[2] : "01";
       const mm = dFim.length >= 2 ? dFim[1] : dIni.length >= 2 ? dIni[1] : "01";
-      const nomeArq = "fechamento_" + String(entNome).replace(/\s+/g, "_") + "_" + ddIni + "_a_" + ddFim + "_" + mm + ".pdf";
+      const fechamentoCode = buildFechamentoCode(fech, entNome);
+      const nomeArq = "fechamento_" + fechamentoCode + "_" + String(entNome).replace(/\s+/g, "_") + "_" + ddIni + "_a_" + ddFim + "_" + mm + ".pdf";
 
       const ajustes = [];
       if ((fech.valor_adicao || 0) > 0) ajustes.push({ tipo: "ADIÇÃO", valor: fech.valor_adicao, motivo: fech.motivo_adicao || "" });

--- a/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
@@ -82,38 +82,15 @@
       return;
     }
     const { jsPDF } = jspdfLib;
-    const doc = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
+    const doc = new jsPDF({ orientation: "landscape", unit: "mm", format: "a4" });
     const pageW = doc.internal.pageSize.getWidth();
+    const pageH = doc.internal.pageSize.getHeight();
+    const M = 10;
+    const FOOTER_RESERVED = 14;
 
     const statusFechamento = normalizeStatus(fech?.status);
     const entNome = fech.username_entregador || fech.entregador_nome || "Motoboy";
     const fechamentoCode = buildFechamentoCode(fech, entNome);
-    let y = 15;
-
-    doc.setFillColor(COR_GRADIENTE_SISTEMA[0], COR_GRADIENTE_SISTEMA[1], COR_GRADIENTE_SISTEMA[2]);
-    doc.rect(0, 0, pageW, 22, "F");
-    doc.setTextColor(255, 255, 255);
-    doc.setFontSize(18);
-    doc.setFont("helvetica", "bold");
-    doc.text("FECHAMENTO DE ENTREGAS — MOTOBOY", 105, y + 4, { align: "center" });
-    doc.setFont("helvetica", "normal");
-    doc.setTextColor(0, 0, 0);
-    y = 28;
-    linhaHorizontal(doc, y, 14, pageW - 14);
-    y += 8;
-
-    // 1.2 Informações iniciais (linhas separadas, espaçamento confortável)
-    doc.setFontSize(10);
-    doc.text("Código do fechamento: " + fechamentoCode, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Status: " + statusFechamento, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Entregador: " + entNome, MARGEM, y);
-    y += ESPACO_SECAO;
-    doc.text("Período: " + fmtData(fech.periodo_inicio) + " a " + fmtData(fech.periodo_fim), MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Data de geração: " + new Date().toLocaleString("pt-BR"), MARGEM, y);
-    y += ESPACO_SECAO;
 
     const sumShopee = itensDiarios.reduce((s, r) => s + (r.shopee?.qtde ?? 0), 0);
     const sumFlex = itensDiarios.reduce((s, r) => s + (r.flex?.qtde ?? 0), 0);
@@ -125,53 +102,80 @@
     const valorBaseCalculado = valorFeitos - valorCancelados;
     const totalAjustes = (fech.valor_adicao || 0) - (fech.valor_subtracao || 0);
 
-    // 1.3 Pacotes Grandes (G) — totalizador e lista
     const pacotesGNorm = (pacotesG || []).map((p) => ({
       data: p.timestamp || p.data || null,
       codigo: p.codigo || "",
       servico: p.servico || "",
     }));
     const totalGShopee = pacotesGNorm.filter((p) => String(p.servico || "").toLowerCase().includes("shopee")).length;
-    const totalGMercado = pacotesGNorm.filter((p) => String(p.servico || "").toLowerCase().includes("mercado")).length;
+    const totalGMercado = pacotesGNorm.filter((p) => {
+      const s = String(p.servico || "").toLowerCase();
+      return s.includes("mercado") || s.includes("flex") || s === "ml";
+    }).length;
     const totalGAvulso = pacotesGNorm.filter((p) => {
       const s = String(p.servico || "").toLowerCase();
-      return !s.includes("shopee") && !s.includes("mercado");
+      return !s.includes("shopee") && !s.includes("mercado") && !s.includes("flex") && s !== "ml";
     }).length;
     const totalG = pacotesGNorm.length;
 
-    doc.setFontSize(11);
-    doc.setFont("helvetica", "bold");
-    doc.text("Resumo do fechamento", MARGEM, y);
-    doc.setFont("helvetica", "normal");
-    y += ESPACO_LINHA;
-    doc.setFontSize(10);
-    doc.text(`Total feitos: ${totalFeitos}`, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text(`Cancelados: ${totalCancelados}`, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text(`Pacotes grandes: ${totalG}`, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text(`Valor bruto das entregas: ${fmt(valorFeitos)}`, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text(`Desconto por cancelamentos: ${fmtDesconto(valorCancelados)}`, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text(`Ajustes manuais: ${fmtSigned(totalAjustes)}`, MARGEM, y);
-    y += ESPACO_LINHA + 1;
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(12);
-    doc.text(`TOTAL A PAGAR: ${fmt(fech.valor_final)}`, MARGEM, y);
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(10);
-    y += ESPACO_SECAO;
+    const ensureSpace = (y, needed) => {
+      if (y + needed <= pageH - FOOTER_RESERVED) return y;
+      doc.addPage();
+      let ny = 14;
+      doc.setFontSize(11);
+      doc.setFont("helvetica", "bold");
+      doc.text("FECHAMENTO DE ENTREGAS — MOTOBOY (continuação)", M, ny);
+      ny += 4;
+      linhaHorizontal(doc, ny, M, pageW - M);
+      return ny + 4;
+    };
 
-    // 2. RESUMO FINANCEIRO
-    linhaHorizontal(doc, y, MARGEM, pageW - MARGEM);
-    y += 6;
-    doc.setFontSize(11);
+    let y = 12;
+    doc.setFillColor(COR_GRADIENTE_SISTEMA[0], COR_GRADIENTE_SISTEMA[1], COR_GRADIENTE_SISTEMA[2]);
+    doc.rect(0, 0, pageW, 18, "F");
+    doc.setTextColor(255, 255, 255);
+    doc.setFontSize(15);
     doc.setFont("helvetica", "bold");
-    doc.text("Resumo Financeiro", MARGEM, y);
+    doc.text("FECHAMENTO DE ENTREGAS — MOTOBOY", pageW / 2, y, { align: "center" });
+    doc.setTextColor(0, 0, 0);
     doc.setFont("helvetica", "normal");
-    y += ESPACO_LINHA;
+    y = 22;
+    linhaHorizontal(doc, y, M, pageW - M);
+    y += 5;
+
+    doc.setFontSize(9.5);
+    doc.text(`Código: ${fechamentoCode}`, M, y);
+    doc.text(`Status: ${statusFechamento}`, M + 78, y);
+    doc.text(`Entregador: ${entNome}`, M + 130, y);
+    y += 4.5;
+    doc.text(`Período: ${fmtData(fech.periodo_inicio)} a ${fmtData(fech.periodo_fim)}`, M, y);
+    doc.text(`Geração: ${new Date().toLocaleString("pt-BR")}`, M + 130, y);
+    y += 6;
+
+    y = ensureSpace(y, 14);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(10.5);
+    doc.text("Resumo do fechamento", M, y);
+    doc.setFont("helvetica", "normal");
+    y += 4.5;
+    doc.setFontSize(9);
+    const resumoLinha =
+      `Feitos: ${totalFeitos} | Cancelados: ${totalCancelados} | G: ${totalG} | ` +
+      `Bruto: ${fmt(valorFeitos)} | Desc.: ${fmtDesconto(valorCancelados)} | Ajustes: ${fmtSigned(totalAjustes)}`;
+    doc.text(resumoLinha, M, y);
+    y += 4.5;
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(11.5);
+    doc.text(`TOTAL A PAGAR: ${fmt(fech.valor_final)}`, M, y);
+    doc.setFont("helvetica", "normal");
+    y += 6;
+
+    y = ensureSpace(y, 24);
+    doc.setFontSize(10.5);
+    doc.setFont("helvetica", "bold");
+    doc.text("Resumo Financeiro", M, y);
+    doc.setFont("helvetica", "normal");
+    y += 4;
     doc.autoTable({
       startY: y,
       head: [["Descrição", "Valor"]],
@@ -184,29 +188,28 @@
         ["TOTAL A PAGAR", fmt(fech.valor_final)],
       ],
       theme: "grid",
+      margin: { left: M, right: M, bottom: FOOTER_RESERVED + 2 },
+      styles: { fontSize: 8.6, cellPadding: 1.8, overflow: "linebreak" },
       headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
-      columnStyles: {
-        0: { halign: "left" },
-        1: { halign: "right" },
-      },
+      columnStyles: { 0: { halign: "left" }, 1: { halign: "right" } },
       didParseCell: function (data) {
         if (data.row.section === "body" && data.row.index === 5) {
           data.cell.styles.fontStyle = "bold";
           data.cell.styles.fillColor = [245, 245, 245];
         }
       },
-      margin: { left: MARGEM },
-      styles: { fontSize: 9 },
+      pageBreak: "auto",
+      rowPageBreak: "avoid",
     });
-    y = doc.lastAutoTable.finalY + ESPACO_SECAO;
+    y = doc.lastAutoTable.finalY + 5;
 
-    // 3. TABELA DIÁRIA — cabeçalho destacado, espaçamento confortável, valores R$ com 2 decimais
-    doc.setFontSize(11);
+    y = ensureSpace(y, 12);
+    doc.setFontSize(10.5);
     doc.setFont("helvetica", "bold");
-    doc.text("Detalhamento por dia", MARGEM, y);
+    doc.text("Detalhamento por dia", M, y);
     doc.setFont("helvetica", "normal");
-    y += ESPACO_LINHA;
-    const colsDiaria = ["Data", "Flex", "Shopee", "Avulso", "G", "Total Feitos", "Cancelados", "Valor Feitos", "Valor Cancelados", "Valor Total"];
+    y += 4;
+    const colsDiaria = ["Data", "Flex", "Shopee", "Avulso", "G", "Feitos", "Canc.", "Valor feitos", "Valor canc.", "Total"];
     const rowsDiaria = itensDiarios.map((r) => [
       fmtData(r.data),
       r.flex?.qtde ?? 0,
@@ -216,7 +219,7 @@
       r.total_feitos ?? ((r.shopee?.qtde ?? 0) + (r.flex?.qtde ?? 0) + (r.avulso?.qtde ?? 0)),
       r.total_cancelado ?? 0,
       fmt(r.valor_feitos),
-      fmt(r.valor_cancelados),
+      fmtDesconto(r.valor_cancelados),
       fmt(r.valor_total != null ? r.valor_total : r.total_dia),
     ]);
     doc.autoTable({
@@ -224,30 +227,24 @@
       head: [colsDiaria],
       body: rowsDiaria,
       theme: "grid",
-      headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
+      margin: { left: M, right: M, bottom: FOOTER_RESERVED + 2 },
+      styles: { fontSize: 8.2, cellPadding: 1.4, overflow: "linebreak" },
+      headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold", fontSize: 8.2 },
       columnStyles: {
-        1: { halign: "right" },
-        2: { halign: "right" },
-        3: { halign: "right" },
-        4: { halign: "right" },
-        5: { halign: "right" },
-        6: { halign: "right" },
-        7: { halign: "right" },
-        8: { halign: "right" },
-        9: { halign: "right" },
+        1: { halign: "right" }, 2: { halign: "right" }, 3: { halign: "right" }, 4: { halign: "right" },
+        5: { halign: "right" }, 6: { halign: "right" }, 7: { halign: "right" }, 8: { halign: "right" }, 9: { halign: "right" },
       },
-      margin: { left: MARGEM },
-      tableLineColor: [200, 200, 200],
-      cellPadding: 3,
+      pageBreak: "auto",
+      rowPageBreak: "avoid",
     });
-    y = doc.lastAutoTable.finalY + ESPACO_SECAO;
+    y = doc.lastAutoTable.finalY + 5;
 
-    // 4. TABELA DE AJUSTES — cabeçalho destacado; se vazio: mensagem
-    doc.setFontSize(11);
+    y = ensureSpace(y, ajustes.length ? 18 : 10);
+    doc.setFontSize(10.5);
     doc.setFont("helvetica", "bold");
-    doc.text("Ajustes Manuais", MARGEM, y);
+    doc.text("Ajustes Manuais", M, y);
     doc.setFont("helvetica", "normal");
-    y += ESPACO_LINHA;
+    y += 4;
     if (ajustes.length) {
       const tipoAjuste = (a) => (a.tipo === "ADIÇÃO" ? "Acréscimo" : "Desconto");
       const valorComSinal = (a) => (a.tipo === "ADIÇÃO" ? fmtSigned(a.valor) : fmtSigned(-Math.abs(a.valor)));
@@ -256,32 +253,29 @@
         head: [["Tipo", "Justificativa", "Valor"]],
         body: ajustes.map((a) => [tipoAjuste(a), a.motivo || "—", valorComSinal(a)]),
         theme: "grid",
+        margin: { left: M, right: M, bottom: FOOTER_RESERVED + 2 },
+        styles: { fontSize: 8.6, cellPadding: 1.6 },
         headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
         columnStyles: { 2: { halign: "right" } },
-        margin: { left: MARGEM },
-        tableLineColor: [200, 200, 200],
-        cellPadding: 3,
+        pageBreak: "auto",
+        rowPageBreak: "avoid",
       });
-      y = doc.lastAutoTable.finalY + ESPACO_SECAO;
+      y = doc.lastAutoTable.finalY + 5;
     } else {
-      doc.setFontSize(10);
+      doc.setFontSize(8.8);
       doc.setTextColor(100, 100, 100);
-      doc.text("Nenhum ajuste manual aplicado.", MARGEM, y);
+      doc.text("Nenhum ajuste manual aplicado.", M, y);
       doc.setTextColor(0, 0, 0);
-      y += ESPACO_SECAO;
+      y += 5;
     }
 
-    // 5. PACOTES G
-    doc.setFontSize(11);
-    doc.setFont("helvetica", "bold");
-    doc.text("Pacotes Grandes", MARGEM, y);
-    doc.setFont("helvetica", "normal");
-    y += ESPACO_LINHA;
-    if (!pacotesGNorm.length) {
-      doc.setFontSize(10);
-      doc.text("Nenhum pacote grande no período.", MARGEM, y);
-      y += ESPACO_SECAO;
-    } else {
+    if (totalG > 0) {
+      y = ensureSpace(y, 16);
+      doc.setFontSize(10.5);
+      doc.setFont("helvetica", "bold");
+      doc.text("Pacotes Grandes", M, y);
+      doc.setFont("helvetica", "normal");
+      y += 4;
       doc.autoTable({
         startY: y,
         head: [["Serviço", "Quantidade G"]],
@@ -292,43 +286,32 @@
           ["Total", totalG],
         ],
         theme: "grid",
+        margin: { left: M, right: M, bottom: FOOTER_RESERVED + 2 },
+        styles: { fontSize: 8.6, cellPadding: 1.6 },
         headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
         columnStyles: { 1: { halign: "right" } },
-        margin: { left: MARGEM },
-        styles: { fontSize: 9 },
       });
-      y = doc.lastAutoTable.finalY + ESPACO_SECAO;
+      y = doc.lastAutoTable.finalY + 5;
     }
 
-    // 6. Critério de cálculo
-    doc.setFontSize(11);
+    y = ensureSpace(y, 14);
+    doc.setFontSize(10.5);
     doc.setFont("helvetica", "bold");
-    doc.text("Critério de cálculo", MARGEM, y);
+    doc.text("Critério de cálculo", M, y);
     doc.setFont("helvetica", "normal");
-    y += ESPACO_LINHA;
-    doc.setFontSize(9);
-    const criterio = [
-      "• O valor bruto das entregas corresponde à soma das entregas feitas no período.",
-      "• Cancelamentos são exibidos separadamente e abatidos do valor bruto quando aplicável.",
-      "• O valor base corresponde ao valor bruto das entregas menos o desconto por cancelamentos.",
-      "• Ajustes manuais podem somar ou descontar valores do fechamento.",
-      "• Pacotes grandes são identificados pela coluna G e podem ter tratamento específico conforme regra vigente.",
-      "• O Total a pagar representa o valor final calculado para o período.",
-    ];
-    criterio.forEach((linha) => {
-      doc.text(linha, MARGEM, y);
-      y += 4.5;
-    });
     y += 4;
+    doc.setFontSize(8.6);
+    doc.text("Valor base = valor bruto das entregas - cancelamentos.", M, y); y += 3.8;
+    doc.text("Total a pagar = valor base + ajustes manuais + adicionais aplicáveis.", M, y); y += 3.8;
+    doc.text("Pacotes grandes são identificados pela coluna G e seguem a regra vigente.", M, y);
 
-    // 7. Rodapé de validação digital
     const ano = new Date().getFullYear();
-    doc.setFontSize(8.5);
+    doc.setFontSize(8.2);
     doc.setTextColor(80);
-    const footerY = doc.internal.pageSize.height - 16;
-    doc.text("Documento gerado digitalmente pelo sistema.", 105, footerY, { align: "center" });
-    doc.text(`Código do fechamento: ${fechamentoCode} · Status: ${statusFechamento}`, 105, footerY + 4, { align: "center" });
-    doc.text(`Data de geração: ${new Date().toLocaleString("pt-BR")} · ${ano} © TrackingSaídas.`, 105, footerY + 8, { align: "center" });
+    const footerY = pageH - 10;
+    doc.text("Documento gerado digitalmente pelo sistema.", pageW / 2, footerY - 4, { align: "center" });
+    doc.text(`Código do fechamento: ${fechamentoCode} · Status: ${statusFechamento}`, pageW / 2, footerY, { align: "center" });
+    doc.text(`Data de geração: ${new Date().toLocaleString("pt-BR")} · ${ano} © TrackingSaídas.`, pageW / 2, footerY + 4, { align: "center" });
     doc.save(nomeArq);
   }
 

--- a/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
@@ -14,6 +14,15 @@
 
   const fmt = (v) =>
     new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(Number(v) || 0);
+  const fmtSigned = (v) => {
+    const n = Number(v) || 0;
+    if (n === 0) return fmt(0);
+    return `${n > 0 ? "+" : "-"} ${fmt(Math.abs(n))}`;
+  };
+  const fmtDesconto = (v) => {
+    const n = Number(v) || 0;
+    return n > 0 ? `- ${fmt(n)}` : fmt(0);
+  };
   const fmtData = (ymd) => {
     if (!ymd) return "—";
     const [y, m, d] = String(ymd).split("-");
@@ -113,6 +122,7 @@
     const totalCancelados = itensDiarios.reduce((s, r) => s + Number(r.total_cancelado ?? 0), 0);
     const valorFeitos = itensDiarios.reduce((s, r) => s + Number(r.valor_feitos ?? 0), 0);
     const valorCancelados = itensDiarios.reduce((s, r) => s + Number(r.valor_cancelados ?? 0), 0);
+    const valorBaseCalculado = valorFeitos - valorCancelados;
     const totalAjustes = (fech.valor_adicao || 0) - (fech.valor_subtracao || 0);
 
     // 1.3 Pacotes Grandes (G) — totalizador e lista
@@ -141,11 +151,11 @@
     y += ESPACO_LINHA;
     doc.text(`Pacotes grandes: ${totalG}`, MARGEM, y);
     y += ESPACO_LINHA;
-    doc.text(`Valor feitos: ${fmt(valorFeitos)}`, MARGEM, y);
+    doc.text(`Valor bruto das entregas: ${fmt(valorFeitos)}`, MARGEM, y);
     y += ESPACO_LINHA;
-    doc.text(`Valor cancelados: ${fmt(valorCancelados)}`, MARGEM, y);
+    doc.text(`Desconto por cancelamentos: ${fmtDesconto(valorCancelados)}`, MARGEM, y);
     y += ESPACO_LINHA;
-    doc.text(`Ajustes: ${fmt(totalAjustes)}`, MARGEM, y);
+    doc.text(`Ajustes manuais: ${fmtSigned(totalAjustes)}`, MARGEM, y);
     y += ESPACO_LINHA + 1;
     doc.setFont("helvetica", "bold");
     doc.setFontSize(12);
@@ -154,46 +164,43 @@
     doc.setFontSize(10);
     y += ESPACO_SECAO;
 
+    // 2. RESUMO FINANCEIRO
+    linhaHorizontal(doc, y, MARGEM, pageW - MARGEM);
+    y += 6;
     doc.setFontSize(11);
     doc.setFont("helvetica", "bold");
-    doc.text("Pacotes Grandes (G)", MARGEM, y);
+    doc.text("Resumo Financeiro", MARGEM, y);
     doc.setFont("helvetica", "normal");
     y += ESPACO_LINHA;
-    doc.setFontSize(10);
-    doc.text(`Total G Shopee: ${totalGShopee}`, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text(`Total G Mercado Livre: ${totalGMercado}`, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text(`Total G Avulso: ${totalGAvulso}`, MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text(`Total G (geral): ${totalG}`, MARGEM, y);
-    y += ESPACO_LINHA;
+    doc.autoTable({
+      startY: y,
+      head: [["Descrição", "Valor"]],
+      body: [
+        ["Valor bruto das entregas", fmt(valorFeitos)],
+        ["Desconto por cancelamentos", fmtDesconto(valorCancelados)],
+        ["Valor base", fmt(valorBaseCalculado)],
+        ["Ajustes manuais", fmtSigned(totalAjustes)],
+        ["Adicional pacote grande", fmt(0)],
+        ["TOTAL A PAGAR", fmt(fech.valor_final)],
+      ],
+      theme: "grid",
+      headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
+      columnStyles: {
+        0: { halign: "left" },
+        1: { halign: "right" },
+      },
+      didParseCell: function (data) {
+        if (data.row.section === "body" && data.row.index === 5) {
+          data.cell.styles.fontStyle = "bold";
+          data.cell.styles.fillColor = [245, 245, 245];
+        }
+      },
+      margin: { left: MARGEM },
+      styles: { fontSize: 9 },
+    });
+    y = doc.lastAutoTable.finalY + ESPACO_SECAO;
 
-    if (pacotesGNorm.length) {
-      const rowsG = pacotesGNorm
-        .slice()
-        .sort((a, b) => String(a.data || "").localeCompare(String(b.data || "")))
-        .map((p) => [
-          fmtData((p.data || "").slice(0, 10)),
-          p.codigo || "—",
-          p.servico || "—",
-        ]);
-      doc.autoTable({
-        startY: y,
-        head: [["Data do registro", "Código", "Serviço"]],
-        body: rowsG,
-        theme: "grid",
-        headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
-        margin: { left: MARGEM },
-        styles: { fontSize: 9, halign: "center" },
-      });
-      y = doc.lastAutoTable.finalY + ESPACO_SECAO;
-    } else {
-      doc.text("Nenhum pacote G (Grande) no período.", MARGEM, y);
-      y += ESPACO_SECAO;
-    }
-
-    // 2. TABELA DIÁRIA — cabeçalho destacado, espaçamento confortável, valores R$ com 2 decimais
+    // 3. TABELA DIÁRIA — cabeçalho destacado, espaçamento confortável, valores R$ com 2 decimais
     doc.setFontSize(11);
     doc.setFont("helvetica", "bold");
     doc.text("Detalhamento por dia", MARGEM, y);
@@ -235,7 +242,36 @@
     });
     y = doc.lastAutoTable.finalY + ESPACO_SECAO;
 
-    // 3. PACOTES G
+    // 4. TABELA DE AJUSTES — cabeçalho destacado; se vazio: mensagem
+    doc.setFontSize(11);
+    doc.setFont("helvetica", "bold");
+    doc.text("Ajustes Manuais", MARGEM, y);
+    doc.setFont("helvetica", "normal");
+    y += ESPACO_LINHA;
+    if (ajustes.length) {
+      const tipoAjuste = (a) => (a.tipo === "ADIÇÃO" ? "Acréscimo" : "Desconto");
+      const valorComSinal = (a) => (a.tipo === "ADIÇÃO" ? fmtSigned(a.valor) : fmtSigned(-Math.abs(a.valor)));
+      doc.autoTable({
+        startY: y,
+        head: [["Tipo", "Justificativa", "Valor"]],
+        body: ajustes.map((a) => [tipoAjuste(a), a.motivo || "—", valorComSinal(a)]),
+        theme: "grid",
+        headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
+        columnStyles: { 2: { halign: "right" } },
+        margin: { left: MARGEM },
+        tableLineColor: [200, 200, 200],
+        cellPadding: 3,
+      });
+      y = doc.lastAutoTable.finalY + ESPACO_SECAO;
+    } else {
+      doc.setFontSize(10);
+      doc.setTextColor(100, 100, 100);
+      doc.text("Nenhum ajuste manual aplicado.", MARGEM, y);
+      doc.setTextColor(0, 0, 0);
+      y += ESPACO_SECAO;
+    }
+
+    // 5. PACOTES G
     doc.setFontSize(11);
     doc.setFont("helvetica", "bold");
     doc.text("Pacotes Grandes", MARGEM, y);
@@ -243,7 +279,7 @@
     y += ESPACO_LINHA;
     if (!pacotesGNorm.length) {
       doc.setFontSize(10);
-      doc.text("Pacotes Grandes: nenhum pacote grande no período.", MARGEM, y);
+      doc.text("Nenhum pacote grande no período.", MARGEM, y);
       y += ESPACO_SECAO;
     } else {
       doc.autoTable({
@@ -264,34 +300,7 @@
       y = doc.lastAutoTable.finalY + ESPACO_SECAO;
     }
 
-    // 4. TABELA DE AJUSTES — cabeçalho destacado; se vazio: mensagem
-    doc.setFontSize(11);
-    doc.setFont("helvetica", "bold");
-    doc.text("Ajustes Manuais", MARGEM, y);
-    doc.setFont("helvetica", "normal");
-    y += ESPACO_LINHA;
-    if (ajustes.length) {
-      const valorComSinal = (a) => (a.tipo === "ADIÇÃO" ? "+ " + fmt(a.valor) : "- " + fmt(a.valor));
-      doc.autoTable({
-        startY: y,
-        head: [["Tipo", "Justificativa", "Valor"]],
-        body: ajustes.map((a) => [(a.tipo === "ADIÇÃO" ? "+ Adição" : "- Subtração"), a.motivo || "—", valorComSinal(a)]),
-        theme: "grid",
-        headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
-        margin: { left: MARGEM },
-        tableLineColor: [200, 200, 200],
-        cellPadding: 3,
-      });
-      y = doc.lastAutoTable.finalY + ESPACO_SECAO;
-    } else {
-      doc.setFontSize(10);
-      doc.setTextColor(100, 100, 100);
-      doc.text("Nenhum ajuste manual aplicado.", MARGEM, y);
-      doc.setTextColor(0, 0, 0);
-      y += ESPACO_SECAO;
-    }
-
-    // 5. Critério de cálculo
+    // 6. Critério de cálculo
     doc.setFontSize(11);
     doc.setFont("helvetica", "bold");
     doc.text("Critério de cálculo", MARGEM, y);
@@ -299,10 +308,11 @@
     y += ESPACO_LINHA;
     doc.setFontSize(9);
     const criterio = [
-      "• Entregas concluídas são consideradas no valor de pagamento.",
-      "• Entregas canceladas são exibidas separadamente para conferência.",
-      "• Pacotes grandes são identificados pela coluna G.",
-      "• Ajustes manuais, quando existirem, são somados/subtraídos do valor final.",
+      "• O valor bruto das entregas corresponde à soma das entregas feitas no período.",
+      "• Cancelamentos são exibidos separadamente e abatidos do valor bruto quando aplicável.",
+      "• O valor base corresponde ao valor bruto das entregas menos o desconto por cancelamentos.",
+      "• Ajustes manuais podem somar ou descontar valores do fechamento.",
+      "• Pacotes grandes são identificados pela coluna G e podem ter tratamento específico conforme regra vigente.",
       "• O Total a pagar representa o valor final calculado para o período.",
     ];
     criterio.forEach((linha) => {
@@ -311,32 +321,7 @@
     });
     y += 4;
 
-    // 6. BLOCO "RESUMO FINANCEIRO" — linha antes; TOTAL A PAGAR em destaque
-    linhaHorizontal(doc, y, MARGEM, pageW - MARGEM);
-    y += 6;
-    doc.setFontSize(11);
-    doc.setFont("helvetica", "bold");
-    doc.text("Resumo Financeiro", MARGEM, y);
-    doc.setFont("helvetica", "normal");
-    y += ESPACO_LINHA;
-    doc.setFontSize(10);
-    doc.text("Valor feitos: " + fmt(valorFeitos), MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Valor cancelados: " + fmt(valorCancelados), MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Valor base: " + fmt(fech.valor_base), MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Ajustes manuais: " + fmt(totalAjustes), MARGEM, y);
-    y += ESPACO_LINHA;
-    doc.text("Adicional pacote grande: " + fmt(0), MARGEM, y);
-    y += ESPACO_LINHA + 2;
-    doc.setFontSize(12);
-    doc.setFont("helvetica", "bold");
-    doc.text("TOTAL A PAGAR: " + fmt(fech.valor_final), MARGEM, y);
-    doc.setFont("helvetica", "normal");
-    y += 12;
-
-    // Rodapé de validação digital
+    // 7. Rodapé de validação digital
     const ano = new Date().getFullYear();
     doc.setFontSize(8.5);
     doc.setTextColor(80);

--- a/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
@@ -17,11 +17,11 @@
   const fmtSigned = (v) => {
     const n = Number(v) || 0;
     if (n === 0) return fmt(0);
-    return `${n > 0 ? "+" : "-"} ${fmt(Math.abs(n))}`;
+    return `${n > 0 ? "+" : "-"}${fmt(Math.abs(n))}`;
   };
   const fmtDesconto = (v) => {
     const n = Number(v) || 0;
-    return n > 0 ? `- ${fmt(n)}` : fmt(0);
+    return n > 0 ? `-${fmt(n)}` : fmt(0);
   };
   const fmtData = (ymd) => {
     if (!ymd) return "—";
@@ -143,13 +143,10 @@
     linhaHorizontal(doc, y, M, pageW - M);
     y += 5;
 
-    doc.setFontSize(9.5);
-    doc.text(`Código: ${fechamentoCode}`, M, y);
-    doc.text(`Status: ${statusFechamento}`, M + 78, y);
-    doc.text(`Entregador: ${entNome}`, M + 130, y);
+    doc.setFontSize(9.3);
+    doc.text(`Código: ${fechamentoCode} | Status: ${statusFechamento} | Entregador: ${entNome}`, M, y);
     y += 4.5;
-    doc.text(`Período: ${fmtData(fech.periodo_inicio)} a ${fmtData(fech.periodo_fim)}`, M, y);
-    doc.text(`Geração: ${new Date().toLocaleString("pt-BR")}`, M + 130, y);
+    doc.text(`Período: ${fmtData(fech.periodo_inicio)} a ${fmtData(fech.periodo_fim)} | Geração: ${new Date().toLocaleString("pt-BR")}`, M, y);
     y += 6;
 
     y = ensureSpace(y, 14);
@@ -161,7 +158,7 @@
     doc.setFontSize(9);
     const resumoLinha =
       `Feitos: ${totalFeitos} | Cancelados: ${totalCancelados} | G: ${totalG} | ` +
-      `Bruto: ${fmt(valorFeitos)} | Desc.: ${fmtDesconto(valorCancelados)} | Ajustes: ${fmtSigned(totalAjustes)}`;
+      `Bruto: ${fmt(valorFeitos)} | Canc.: ${fmtDesconto(valorCancelados)} | Ajustes: ${fmtSigned(totalAjustes)}`;
     doc.text(resumoLinha, M, y);
     y += 4.5;
     doc.setFont("helvetica", "bold");
@@ -176,24 +173,32 @@
     doc.text("Resumo Financeiro", M, y);
     doc.setFont("helvetica", "normal");
     y += 4;
+    const adicionalPacoteGrande = Number(
+      fech?.valor_adicional_pacote_grande ?? fech?.valor_pacote_grande ?? 0
+    );
+    const mostrarAdicionalPacote = totalG > 0 || adicionalPacoteGrande > 0;
+    const linhasFinanceiras = [
+      ["Valor bruto das entregas", fmt(valorFeitos)],
+      ["Desconto por cancelamentos", fmtDesconto(valorCancelados)],
+      ["Valor base", fmt(valorBaseCalculado)],
+      ["Ajustes manuais", fmtSigned(totalAjustes)],
+    ];
+    if (mostrarAdicionalPacote) {
+      linhasFinanceiras.push(["Adicional pacote grande", fmt(adicionalPacoteGrande)]);
+    }
+    linhasFinanceiras.push(["TOTAL A PAGAR", fmt(fech.valor_final)]);
+    const idxTotalFinanceiro = linhasFinanceiras.length - 1;
     doc.autoTable({
       startY: y,
       head: [["Descrição", "Valor"]],
-      body: [
-        ["Valor bruto das entregas", fmt(valorFeitos)],
-        ["Desconto por cancelamentos", fmtDesconto(valorCancelados)],
-        ["Valor base", fmt(valorBaseCalculado)],
-        ["Ajustes manuais", fmtSigned(totalAjustes)],
-        ["Adicional pacote grande", fmt(0)],
-        ["TOTAL A PAGAR", fmt(fech.valor_final)],
-      ],
+      body: linhasFinanceiras,
       theme: "grid",
       margin: { left: M, right: M, bottom: FOOTER_RESERVED + 2 },
       styles: { fontSize: 8.6, cellPadding: 1.8, overflow: "linebreak" },
       headStyles: { fillColor: COR_GRADIENTE_SISTEMA, textColor: [255, 255, 255], fontStyle: "bold" },
       columnStyles: { 0: { halign: "left" }, 1: { halign: "right" } },
       didParseCell: function (data) {
-        if (data.row.section === "body" && data.row.index === 5) {
+        if (data.row.section === "body" && data.row.index === idxTotalFinanceiro) {
           data.cell.styles.fontStyle = "bold";
           data.cell.styles.fillColor = [245, 245, 245];
         }

--- a/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
@@ -200,7 +200,9 @@
       didParseCell: function (data) {
         if (data.row.section === "body" && data.row.index === idxTotalFinanceiro) {
           data.cell.styles.fontStyle = "bold";
-          data.cell.styles.fillColor = [245, 245, 245];
+          data.cell.styles.fillColor = [242, 242, 242];
+          data.cell.styles.lineWidth = { top: 0.35, right: 0.1, bottom: 0.1, left: 0.1 };
+          data.cell.styles.lineColor = [140, 140, 140];
         }
       },
       pageBreak: "auto",

--- a/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
@@ -474,6 +474,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (executorTipo === "m" && executorId) calcParams.append("motoboy_id", executorId);
       try {
         const res = await fetch(`${API_FECHAMENTOS}/calcular?${calcParams}`, { credentials: "include" });
+        let calculoComFallback = false;
         if (res.ok) {
           const data = await res.json();
           state.fechModal.valorBase = Number(data.valor_base || 0);
@@ -514,17 +515,20 @@ document.addEventListener("DOMContentLoaded", async () => {
           if (resumoRes.ok) {
             const resumoData = await resumoRes.json();
             const itens = Array.isArray(resumoData.items) ? resumoData.items : [];
-            const valorBase = itens.reduce((s, r) => s + (Number(r.total_dia) || 0), 0);
+            const valorBase = itens.reduce((s, r) => s + (Number(r.valor_total ?? r.total_dia) || 0), 0);
             state.fechModal.valorBase = valorBase;
             qs("#fech-valor-base").value = formatarMoeda(valorBase);
+            calculoComFallback = true;
           } else {
             qs("#fech-valor-base").value = formatarMoeda(0);
           }
-          const titulo = typeof mensagem === "string" && mensagem.toLowerCase().includes("período ainda em aberto")
-            ? "Período inválido para fechamento"
-            : "Não foi possível calcular o fechamento";
-          if (window.Swal) Swal.fire({ icon: "warning", title: titulo, text: mensagem });
-          else alert(mensagem);
+          if (!calculoComFallback) {
+            const titulo = typeof mensagem === "string" && mensagem.toLowerCase().includes("período ainda em aberto")
+              ? "Período inválido para fechamento"
+              : "Não foi possível calcular o fechamento";
+            if (window.Swal) Swal.fire({ icon: "warning", title: titulo, text: mensagem });
+            else alert(mensagem);
+          }
         }
       } catch (err) {
         const resumoParams = new URLSearchParams({ data_inicio: periodoInicio, data_fim: periodoFim, pageSize: 500 });
@@ -535,7 +539,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           if (resumoRes.ok) {
             const resumoData = await resumoRes.json();
             const itens = Array.isArray(resumoData.items) ? resumoData.items : [];
-            const valorBase = itens.reduce((s, r) => s + (Number(r.total_dia) || 0), 0);
+            const valorBase = itens.reduce((s, r) => s + (Number(r.valor_total ?? r.total_dia) || 0), 0);
             state.fechModal.valorBase = valorBase;
             qs("#fech-valor-base").value = formatarMoeda(valorBase);
           } else {

--- a/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
@@ -82,6 +82,36 @@ document.addEventListener("DOMContentLoaded", async () => {
     REAJUSTADO: "Fechamento reajustado",
   };
 
+  function formatarCodigoFechamento(r) {
+    const idFech = Number(r?.id_fechamento || 0);
+    if (!idFech) return "";
+    const periodoRaw = String(r?.data || "");
+    const [y, m] = periodoRaw.split("-");
+    const ym = y && m ? `${y}${m}` : "000000";
+    const entTag = String(r?.entregador_nome || "MOTOBOY")
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[^a-zA-Z0-9]+/g, "")
+      .toUpperCase()
+      .slice(0, 12) || "MOTOBOY";
+    return `FEC-${ym}-${entTag}-${String(idFech).padStart(6, "0")}`;
+  }
+
+  function formatarCodigoFechamentoDetalhe(idFech, periodoFim, periodoInicio, entNome) {
+    const id = Number(idFech || 0);
+    if (!id) return "—";
+    const periodo = String(periodoFim || periodoInicio || "");
+    const [y, m] = periodo.split("-");
+    const ym = y && m ? `${y}${m}` : "000000";
+    const entTag = String(entNome || "MOTOBOY")
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[^a-zA-Z0-9]+/g, "")
+      .toUpperCase()
+      .slice(0, 12) || "MOTOBOY";
+    return `FEC-${ym}-${entTag}-${String(id).padStart(6, "0")}`;
+  }
+
   const PLACEHOLDER_MOTIVO = {
     ADIÇÃO: "Ex: Coletas realizadas (50 x R$ 2,00)",
     SUBTRAÇÃO: "Ex: Adiantamento pago",
@@ -90,18 +120,19 @@ document.addEventListener("DOMContentLoaded", async () => {
   function celulaFechamento(r) {
     const st = (r.fechamento_status || "PENDENTE").toUpperCase();
     const idFech = r.id_fechamento || "";
+    const codigoFech = formatarCodigoFechamento(r);
     let html = "";
     if (st === "PENDENTE") {
       html = '<span class="badge bg-warning-subtle text-warning" title="' + (STATUS_TOOLTIPS.PENDENTE || "Pendente") + '">🟡 PENDENTE</span>';
     } else if (st === "GERADO") {
-      html = '<span class="badge bg-success-subtle text-success" title="' + (STATUS_TOOLTIPS.GERADO || "Gerado") + '">🟢 GERADO</span>';
+      html = '<span class="badge bg-success-subtle text-success" title="' + (STATUS_TOOLTIPS.GERADO || "Gerado") + (codigoFech ? " · " + codigoFech : "") + '">🟢 GERADO</span>';
       if (idFech) {
-        html += ' <button type="button" class="btn btn-link btn-sm p-0 ms-1 btn-pdf-fechamento" title="Gerar PDF" data-id-fech="' + idFech + '"><i class="ri-file-pdf-line text-danger"></i></button>';
+        html += ' <button type="button" class="btn btn-link btn-sm p-0 ms-1 btn-pdf-fechamento" title="Gerar PDF · ' + (codigoFech || "") + '" data-id-fech="' + idFech + '"><i class="ri-file-pdf-line text-danger"></i></button>';
       }
     } else {
-      html = '<span class="badge bg-info-subtle text-info" title="' + (STATUS_TOOLTIPS.REAJUSTADO || "Reajustado") + '">🔵 REAJUSTADO</span>';
+      html = '<span class="badge bg-info-subtle text-info" title="' + (STATUS_TOOLTIPS.REAJUSTADO || "Reajustado") + (codigoFech ? " · " + codigoFech : "") + '">🔵 REAJUSTADO</span>';
       if (idFech) {
-        html += ' <button type="button" class="btn btn-link btn-sm p-0 ms-1 btn-pdf-fechamento" title="Gerar PDF" data-id-fech="' + idFech + '"><i class="ri-file-pdf-line text-danger"></i></button>';
+        html += ' <button type="button" class="btn btn-link btn-sm p-0 ms-1 btn-pdf-fechamento" title="Gerar PDF · ' + (codigoFech || "") + '" data-id-fech="' + idFech + '"><i class="ri-file-pdf-line text-danger"></i></button>';
       }
     }
     return html;
@@ -426,6 +457,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     qs("#fech-periodo-fim").value = periodoFim || "";
     qs("#fech-entregador-nome").textContent = entNome || fltEntregador?.options[fltEntregador.selectedIndex]?.text || "—";
     qs("#fech-periodo-display").textContent = formatarPeriodo(periodoInicio, periodoFim);
+    const codigoEl = qs("#fech-codigo");
+    if (codigoEl) codigoEl.textContent = formatarCodigoFechamentoDetalhe(idFech, periodoFim, periodoInicio, entNome);
 
     const alertDiverg = qs("#fechamentoAlertaDivergencia");
     if (alertDiverg) alertDiverg.classList.add("d-none");

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1396,7 +1396,7 @@ function setupPagerEvents() {
     datePickerInstance = window.initDatePickerDashboard({
       containerId: "registros-date-picker-container",
       prefix: "registros-dp",
-      defaultPreset: "ultimos30",
+      defaultPreset: "ultimos90",
       onApply: function (start, end) {
         if (f.from) f.from.value = start;
         if (f.to) f.to.value = end;
@@ -1416,7 +1416,7 @@ function setupPagerEvents() {
       }
     });
     if (datePickerInstance && datePickerInstance.applyPreset) {
-      datePickerInstance.applyPreset("ultimos30");
+      datePickerInstance.applyPreset("ultimos90");
     }
     const r = datePickerInstance ? datePickerInstance.getResolvedRange() : { start: "", end: "" };
     if (f.from) f.from.value = r.start;
@@ -1426,7 +1426,7 @@ function setupPagerEvents() {
     // fallback: definir período manualmente se date picker não disponível
     const now = new Date();
     const y = now.getFullYear(), m = now.getMonth(), d = now.getDate();
-    const start = new Date(y, m, d - 30);
+    const start = new Date(y, m, d - 90);
     const fmt = (x) => x.getFullYear() + "-" + String(x.getMonth() + 1).padStart(2, "0") + "-" + String(x.getDate()).padStart(2, "0");
     if (f.from) f.from.value = fmt(start);
     if (f.to) f.to.value = fmt(now);
@@ -1482,7 +1482,7 @@ function setupPagerEvents() {
       ativarTodosFiltros();
       if (f.somenteG) f.somenteG.checked = false;
       if (datePickerInstance && datePickerInstance.applyPreset) {
-        datePickerInstance.applyPreset("ultimos30");
+        datePickerInstance.applyPreset("ultimos90");
         const r = datePickerInstance.getResolvedRange();
         if (f.from) f.from.value = r.start;
         if (f.to) f.to.value = r.end;

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -413,12 +413,24 @@ function augmentEntregadoresFromRows(rows){
     if (!r) return r;
 
     var id = getRowId(r);
-    var ts = r.data_hora_acao || r.timestamp || r.ts || r.data_hora || r.datahora || r.date;
+    var tsEntrada = r.timestamp || r.ts || r.data_hora || r.datahora || r.date;
+    var tsAcao = r.data_hora_acao || r.timestamp || r.ts || r.data_hora || r.datahora || r.date;
 
-    var tsFmt = r.tsFmt || (() => {
+    var tsEntradaFmt = (() => {
       try {
-        if (!ts) return "";
-        var d = (ts instanceof Date) ? ts : new Date(ts);
+        if (!tsEntrada) return "";
+        var d = (tsEntrada instanceof Date) ? tsEntrada : new Date(tsEntrada);
+        if (isNaN(d.getTime())) return "";
+        return d.toLocaleString("pt-BR");
+      } catch {
+        return "";
+      }
+    })();
+
+    var tsAcaoFmt = (() => {
+      try {
+        if (!tsAcao) return "";
+        var d = (tsAcao instanceof Date) ? tsAcao : new Date(tsAcao);
         if (isNaN(d.getTime())) return "";
         return d.toLocaleString("pt-BR");
       } catch {
@@ -440,7 +452,8 @@ function augmentEntregadoresFromRows(rows){
     return {
       ...r,
       id,
-      tsFmt,
+      tsEntradaFmt,
+      tsAcaoFmt,
       username,
       acao,
       status: statusUI
@@ -487,7 +500,7 @@ function augmentEntregadoresFromRows(rows){
     if (!tblBody) return;
     if (!rows?.length){
       tblBody.innerHTML =
-        '<tr><td colspan="11" class="text-muted text-center py-4">Sem registros.</td></tr>';
+        '<tr><td colspan="12" class="text-muted text-center py-4">Sem registros.</td></tr>';
       return;
     }
 
@@ -508,7 +521,8 @@ function augmentEntregadoresFromRows(rows){
           <tr data-id="${rid}" class="${rowClass}">
             <td class="expand-icon"><i class="ri-arrow-right-s-line"></i></td>
             <td><input type="checkbox" class="rowchk form-check-input" /></td>
-            <td>${r.tsFmt || ""}</td>
+            <td>${r.tsEntradaFmt || ""}</td>
+            <td>${r.tsAcaoFmt || ""}</td>
             <td>${r.base || "-"}</td>
             <td>${r.username || "-"}</td>
             <td>${r.acao || "-"}</td>

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -444,6 +444,7 @@ function augmentEntregadoresFromRows(rows){
       r.usuario ||
       r.created_by ||
       "-";
+    var seller = r.base || r.seller || "-";
     var acao = r.acao || r.action || "Sem ação";
 
     var rawSt = String(r.status || "").toLowerCase();
@@ -455,6 +456,7 @@ function augmentEntregadoresFromRows(rows){
       tsEntradaFmt,
       tsAcaoFmt,
       username,
+      seller,
       acao,
       status: statusUI
     };
@@ -521,15 +523,15 @@ function augmentEntregadoresFromRows(rows){
           <tr data-id="${rid}" class="${rowClass}">
             <td class="expand-icon"><i class="ri-arrow-right-s-line"></i></td>
             <td><input type="checkbox" class="rowchk form-check-input" /></td>
-            <td>${r.tsEntradaFmt || ""}</td>
-            <td>${r.tsAcaoFmt || ""}</td>
-            <td>${r.base || "-"}</td>
-            <td>${r.username || "-"}</td>
-            <td>${r.acao || "-"}</td>
-            <td>${r.entregador || "-"}</td>
             <td><span class="d-inline-flex align-items-center gap-1">${r.codigo || "-"} <button type="button" class="btn btn-link btn-sm p-0 text-primary" title="Gerar etiqueta" data-etiqueta="${(r.codigo || "").replace(/"/g, "&quot;")}" data-id-saida="${rid || ""}" data-servico="${(r.servico || "").replace(/"/g, "&quot;")}"><i class="ri-printer-line"></i></button></span></td>
             <td><span class="${servicoBadgeClass}">${r.servico || "-"}</span></td>
             <td><span class="${statusBadgeClass}">${r.status || "-"}</span></td>
+            <td>${r.acao || "-"}</td>
+            <td>${r.entregador || "-"}</td>
+            <td>${r.tsAcaoFmt || ""}</td>
+            <td>${r.tsEntradaFmt || ""}</td>
+            <td>${r.username || "-"}</td>
+            <td class="text-muted">${r.seller || "-"}</td>
             <td class="text-center">${gCell}</td>
           </tr>`;
       })

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -191,8 +191,9 @@ function parseCodigoFromBusca(rawInput){
     from: qs("#flt-from"),
     to: qs("#flt-to"),
     entregador: qs("#flt-entregador"),
-    servico: qs("#flt-servico"),
-    status: qs("#flt-status"),
+    servicoToggles: qsa("#flt-servico-toggle .filtro-toggle-item"),
+    statusToggles: qsa("#flt-status-toggle .filtro-toggle-item"),
+    acaoToggles: qsa("#flt-acao-toggle .filtro-toggle-item"),
     somenteG: qs("#flt-somente-g"),
     localizar: qs("#flt-localizar"),
     sort: qs("#flt-sort"),
@@ -341,8 +342,9 @@ function augmentEntregadoresFromRows(rows){
   const to          = f.to?.value || "";
   const base        = document.getElementById("flt-base")?.value || "";
   const entregador  = f.entregador?.value || "";
-  const servico     = f.servico?.value || "";
-  const status      = f.status?.value || "";
+  const servicosSelecionados = (f.servicoToggles || []).filter(el => el.checked).map(el => el.value);
+  const statusSelecionados = (f.statusToggles || []).filter(el => el.checked).map(el => el.value);
+  const acoesSelecionadas = (f.acaoToggles || []).filter(el => el.checked).map(el => el.value);
   const somenteG    = !!f.somenteG?.checked;
   const localizar   = (f.localizar?.value || "").trim();
   const sort        = f.sort?.value || "-ts";
@@ -351,13 +353,6 @@ function augmentEntregadoresFromRows(rows){
   const de  = (from && from.trim()) ? from.trim() : "";
   const ate = (to && to.trim()) ? to.trim() : (de ? de : "");
 
-  // NORMALIZA STATUS PARA API
-  let st = status;
-  if (st === "Saiu para entrega") st = "saiu";
-  else if (st === "Coletado") st = "coletado";
-  else if (st === "Não Coletado") st = "Nao Coletado";
-  else if (st === "Cancelado") st = "cancelado";
-
   const codigoBusca = parseCodigoFromBusca(localizar);
 
   const params = {
@@ -365,8 +360,9 @@ function augmentEntregadoresFromRows(rows){
     ate,
     base,
     entregador,
-    servico,
-    status: st,
+    servico: servicosSelecionados,
+    status: statusSelecionados,
+    acao: acoesSelecionadas,
     localizar: localizar || undefined,
     sort,
     limit: parseInt(f.pageSize?.value || "200", 10)
@@ -390,7 +386,7 @@ function augmentEntregadoresFromRows(rows){
 
   // APENAS REMOVE SE REALMENTE ESTIVER VAZIO
   Object.keys(params).forEach(k => {
-    if (params[k] === "" || params[k] === undefined || params[k] === null) {
+    if (params[k] === "" || params[k] === undefined || params[k] === null || (Array.isArray(params[k]) && params[k].length === 0)) {
       delete params[k];
     }
   });
@@ -1425,8 +1421,15 @@ function setupPagerEvents() {
     let n = 0;
     if ((document.getElementById("flt-base")?.value || "").trim()) n++;
     if ((f.entregador?.value || "").trim()) n++;
-    if ((f.servico?.value || "").trim()) n++;
-    if ((f.status?.value || "").trim()) n++;
+    var totalServico = (f.servicoToggles || []).length;
+    var totalStatus = (f.statusToggles || []).length;
+    var totalAcao = (f.acaoToggles || []).length;
+    var ativosServico = (f.servicoToggles || []).filter(el => el.checked).length;
+    var ativosStatus = (f.statusToggles || []).filter(el => el.checked).length;
+    var ativosAcao = (f.acaoToggles || []).filter(el => el.checked).length;
+    if (totalServico > 0 && ativosServico !== totalServico) n++;
+    if (totalStatus > 0 && ativosStatus !== totalStatus) n++;
+    if (totalAcao > 0 && ativosAcao !== totalAcao) n++;
     if (f.somenteG?.checked) n++;
     if (n > 0) {
       filtrosContadorEl.textContent = String(n);
@@ -1460,8 +1463,9 @@ function setupPagerEvents() {
       const fltBase = document.getElementById("flt-base");
       if (fltBase) fltBase.value = "";
       if (f.entregador) f.entregador.value = "";
-      if (f.servico) f.servico.value = "";
-      if (f.status) f.status.value = "";
+      (f.servicoToggles || []).forEach(el => { el.checked = true; });
+      (f.statusToggles || []).forEach(el => { el.checked = true; });
+      (f.acaoToggles || []).forEach(el => { el.checked = true; });
       if (f.somenteG) f.somenteG.checked = false;
       if (datePickerInstance && datePickerInstance.applyPreset) {
         datePickerInstance.applyPreset("ultimos30");

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -194,6 +194,7 @@ function parseCodigoFromBusca(rawInput){
     servicoToggles: qsa("#flt-servico-toggle .filtro-toggle-item"),
     statusToggles: qsa("#flt-status-toggle .filtro-toggle-item"),
     acaoToggles: qsa("#flt-acao-toggle .filtro-toggle-item"),
+    multiToggle: qs("#flt-multi-toggle"),
     somenteG: qs("#flt-somente-g"),
     localizar: qs("#flt-localizar"),
     sort: qs("#flt-sort"),
@@ -345,6 +346,7 @@ function augmentEntregadoresFromRows(rows){
   const servicosSelecionados = (f.servicoToggles || []).filter(el => el.checked).map(el => el.value);
   const statusSelecionados = (f.statusToggles || []).filter(el => el.checked).map(el => el.value);
   const acoesSelecionadas = (f.acaoToggles || []).filter(el => el.checked).map(el => el.value);
+  const multiAtivo = !!f.multiToggle?.checked;
   const somenteG    = !!f.somenteG?.checked;
   const localizar   = (f.localizar?.value || "").trim();
   const sort        = f.sort?.value || "-ts";
@@ -360,9 +362,9 @@ function augmentEntregadoresFromRows(rows){
     ate,
     base,
     entregador,
-    servico: servicosSelecionados,
-    status: statusSelecionados,
-    acao: acoesSelecionadas,
+    servico: multiAtivo ? servicosSelecionados : servicosSelecionados.slice(0, 1),
+    status: multiAtivo ? statusSelecionados : statusSelecionados.slice(0, 1),
+    acao: multiAtivo ? acoesSelecionadas : acoesSelecionadas.slice(0, 1),
     localizar: localizar || undefined,
     sort,
     limit: parseInt(f.pageSize?.value || "200", 10)
@@ -1431,6 +1433,7 @@ function setupPagerEvents() {
     if (totalStatus > 0 && ativosStatus !== totalStatus) n++;
     if (totalAcao > 0 && ativosAcao !== totalAcao) n++;
     if (f.somenteG?.checked) n++;
+    if (f.multiToggle?.checked) n++;
     if (n > 0) {
       filtrosContadorEl.textContent = String(n);
       filtrosContadorEl.classList.remove("d-none");
@@ -1466,6 +1469,7 @@ function setupPagerEvents() {
       (f.servicoToggles || []).forEach(el => { el.checked = true; });
       (f.statusToggles || []).forEach(el => { el.checked = true; });
       (f.acaoToggles || []).forEach(el => { el.checked = true; });
+      if (f.multiToggle) f.multiToggle.checked = false;
       if (f.somenteG) f.somenteG.checked = false;
       if (datePickerInstance && datePickerInstance.applyPreset) {
         datePickerInstance.applyPreset("ultimos30");
@@ -1479,6 +1483,42 @@ function setupPagerEvents() {
       atualizarContadorFiltros();
       fecharDropdownFiltros();
     };
+  }
+
+  function setupModoSelecao(){
+    var toggles = []
+      .concat(f.servicoToggles || [])
+      .concat(f.statusToggles || [])
+      .concat(f.acaoToggles || []);
+    function aplicarModo(){
+      var multi = !!f.multiToggle?.checked;
+      if (multi) return;
+      var grupos = [f.servicoToggles || [], f.statusToggles || [], f.acaoToggles || []];
+      grupos.forEach(function(grupo){
+        var ativos = grupo.filter(el => el.checked);
+        if (ativos.length > 1){
+          grupo.forEach((el, idx) => { el.checked = idx === grupo.indexOf(ativos[0]); });
+        }
+        if (grupo.length && !grupo.some(el => el.checked)) {
+          grupo[0].checked = true;
+        }
+      });
+    }
+    toggles.forEach(function(el){
+      el.addEventListener("change", function(){
+        if (!f.multiToggle?.checked && el.checked) {
+          var parent = el.closest("#flt-servico-toggle, #flt-status-toggle, #flt-acao-toggle");
+          if (!parent) return;
+          qsa("input.filtro-toggle-item", parent).forEach(function(other){
+            if (other !== el) other.checked = false;
+          });
+        }
+      });
+    });
+    if (f.multiToggle){
+      f.multiToggle.addEventListener("change", aplicarModo);
+    }
+    aplicarModo();
   }
   if (btnFiltroCancelar) {
     btnFiltroCancelar.onclick = fecharDropdownFiltros;
@@ -1502,6 +1542,7 @@ function setupPagerEvents() {
       refresh(false);
       updateEditButtonState();
       if (typeof atualizarContadorFiltros === "function") atualizarContadorFiltros();
+      setupModoSelecao();
       if (typeof window.applyOwnerLabels === "function") window.applyOwnerLabels();
     });
 

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1396,7 +1396,7 @@ function setupPagerEvents() {
     datePickerInstance = window.initDatePickerDashboard({
       containerId: "registros-date-picker-container",
       prefix: "registros-dp",
-      defaultPreset: "ultimos90",
+      defaultPreset: "ultimos45",
       onApply: function (start, end) {
         if (f.from) f.from.value = start;
         if (f.to) f.to.value = end;
@@ -1416,7 +1416,7 @@ function setupPagerEvents() {
       }
     });
     if (datePickerInstance && datePickerInstance.applyPreset) {
-      datePickerInstance.applyPreset("ultimos90");
+      datePickerInstance.applyPreset("ultimos45");
     }
     const r = datePickerInstance ? datePickerInstance.getResolvedRange() : { start: "", end: "" };
     if (f.from) f.from.value = r.start;
@@ -1426,7 +1426,7 @@ function setupPagerEvents() {
     // fallback: definir período manualmente se date picker não disponível
     const now = new Date();
     const y = now.getFullYear(), m = now.getMonth(), d = now.getDate();
-    const start = new Date(y, m, d - 90);
+    const start = new Date(y, m, d - 45);
     const fmt = (x) => x.getFullYear() + "-" + String(x.getMonth() + 1).padStart(2, "0") + "-" + String(x.getDate()).padStart(2, "0");
     if (f.from) f.from.value = fmt(start);
     if (f.to) f.to.value = fmt(now);
@@ -1482,7 +1482,7 @@ function setupPagerEvents() {
       ativarTodosFiltros();
       if (f.somenteG) f.somenteG.checked = false;
       if (datePickerInstance && datePickerInstance.applyPreset) {
-        datePickerInstance.applyPreset("ultimos90");
+        datePickerInstance.applyPreset("ultimos45");
         const r = datePickerInstance.getResolvedRange();
         if (f.from) f.from.value = r.start;
         if (f.to) f.to.value = r.end;

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -194,7 +194,6 @@ function parseCodigoFromBusca(rawInput){
     servicoToggles: qsa("#flt-servico-toggle .filtro-toggle-item"),
     statusToggles: qsa("#flt-status-toggle .filtro-toggle-item"),
     acaoToggles: qsa("#flt-acao-toggle .filtro-toggle-item"),
-    multiToggle: qs("#flt-multi-toggle"),
     somenteG: qs("#flt-somente-g"),
     localizar: qs("#flt-localizar"),
     sort: qs("#flt-sort"),
@@ -346,7 +345,6 @@ function augmentEntregadoresFromRows(rows){
   const servicosSelecionados = (f.servicoToggles || []).filter(el => el.checked).map(el => el.value);
   const statusSelecionados = (f.statusToggles || []).filter(el => el.checked).map(el => el.value);
   const acoesSelecionadas = (f.acaoToggles || []).filter(el => el.checked).map(el => el.value);
-  const multiAtivo = !!f.multiToggle?.checked;
   const somenteG    = !!f.somenteG?.checked;
   const localizar   = (f.localizar?.value || "").trim();
   const sort        = f.sort?.value || "-ts";
@@ -362,9 +360,9 @@ function augmentEntregadoresFromRows(rows){
     ate,
     base,
     entregador,
-    servico: multiAtivo ? servicosSelecionados : servicosSelecionados.slice(0, 1),
-    status: multiAtivo ? statusSelecionados : statusSelecionados.slice(0, 1),
-    acao: multiAtivo ? acoesSelecionadas : acoesSelecionadas.slice(0, 1),
+    servico: servicosSelecionados,
+    status: statusSelecionados,
+    acao: acoesSelecionadas,
     localizar: localizar || undefined,
     sort,
     limit: parseInt(f.pageSize?.value || "200", 10)
@@ -1433,7 +1431,6 @@ function setupPagerEvents() {
     if (totalStatus > 0 && ativosStatus !== totalStatus) n++;
     if (totalAcao > 0 && ativosAcao !== totalAcao) n++;
     if (f.somenteG?.checked) n++;
-    if (f.multiToggle?.checked) n++;
     if (n > 0) {
       filtrosContadorEl.textContent = String(n);
       filtrosContadorEl.classList.remove("d-none");
@@ -1466,10 +1463,7 @@ function setupPagerEvents() {
       const fltBase = document.getElementById("flt-base");
       if (fltBase) fltBase.value = "";
       if (f.entregador) f.entregador.value = "";
-      (f.servicoToggles || []).forEach(el => { el.checked = true; });
-      (f.statusToggles || []).forEach(el => { el.checked = true; });
-      (f.acaoToggles || []).forEach(el => { el.checked = true; });
-      if (f.multiToggle) f.multiToggle.checked = false;
+      ativarTodosFiltros();
       if (f.somenteG) f.somenteG.checked = false;
       if (datePickerInstance && datePickerInstance.applyPreset) {
         datePickerInstance.applyPreset("ultimos30");
@@ -1491,14 +1485,8 @@ function setupPagerEvents() {
       .concat(f.statusToggles || [])
       .concat(f.acaoToggles || []);
     function aplicarModo(){
-      var multi = !!f.multiToggle?.checked;
-      if (multi) return;
       var grupos = [f.servicoToggles || [], f.statusToggles || [], f.acaoToggles || []];
       grupos.forEach(function(grupo){
-        var ativos = grupo.filter(el => el.checked);
-        if (ativos.length > 1){
-          grupo.forEach((el, idx) => { el.checked = idx === grupo.indexOf(ativos[0]); });
-        }
         if (grupo.length && !grupo.some(el => el.checked)) {
           grupo[0].checked = true;
         }
@@ -1506,19 +1494,21 @@ function setupPagerEvents() {
     }
     toggles.forEach(function(el){
       el.addEventListener("change", function(){
-        if (!f.multiToggle?.checked && el.checked) {
-          var parent = el.closest("#flt-servico-toggle, #flt-status-toggle, #flt-acao-toggle");
-          if (!parent) return;
-          qsa("input.filtro-toggle-item", parent).forEach(function(other){
-            if (other !== el) other.checked = false;
-          });
+        var parent = el.closest("#flt-servico-toggle, #flt-status-toggle, #flt-acao-toggle");
+        if (!parent) return;
+        var grupo = qsa("input.filtro-toggle-item", parent);
+        if (grupo.length && !grupo.some(function(item){ return item.checked; })) {
+          el.checked = true;
         }
       });
     });
-    if (f.multiToggle){
-      f.multiToggle.addEventListener("change", aplicarModo);
-    }
     aplicarModo();
+  }
+
+  function ativarTodosFiltros(){
+    (f.servicoToggles || []).forEach(el => { el.checked = true; });
+    (f.statusToggles || []).forEach(el => { el.checked = true; });
+    (f.acaoToggles || []).forEach(el => { el.checked = true; });
   }
   if (btnFiltroCancelar) {
     btnFiltroCancelar.onclick = fecharDropdownFiltros;
@@ -1538,6 +1528,7 @@ function setupPagerEvents() {
       fillEntregadores(unicos);
     })
     .finally(() => {
+      ativarTodosFiltros();
       if (f.pageSize) f.pageSize.value = String(state.pageSize);
       refresh(false);
       updateEditButtonState();

--- a/Master/src/assets/scss/custom.scss
+++ b/Master/src/assets/scss/custom.scss
@@ -464,6 +464,7 @@
 .card-er-flex .small,
 .card-er-shopee .small,
 .card-er-avulso .small,
+.card-er-cancelado .small,
 .card-er-total .small,
 .card-er-valor .small {
   color: #6c757d !important;
@@ -471,6 +472,7 @@
 .card-er-flex .fs-5,
 .card-er-shopee .fs-5,
 .card-er-avulso .fs-5,
+.card-er-cancelado .fs-5,
 .card-er-total .fs-5,
 .card-er-valor .fs-5 {
   font-size: 1.5rem !important;
@@ -495,6 +497,11 @@
   background: linear-gradient(135deg, rgba(13, 110, 253, 0.08) 0%, rgba(13, 110, 253, 0.14) 100%);
   border: 1px solid rgba(13, 110, 253, 0.45);
   color: #0d6efd;
+}
+.card-er-cancelado {
+  background: linear-gradient(135deg, rgba(108, 117, 125, 0.08) 0%, rgba(108, 117, 125, 0.14) 100%);
+  border: 1px solid rgba(108, 117, 125, 0.45);
+  color: #6c757d;
 }
 .card-er-total {
   background: linear-gradient(135deg, rgba(111, 66, 193, 0.08) 0%, rgba(111, 66, 193, 0.14) 100%);

--- a/Master/src/tracking-entregadores-resumo.html
+++ b/Master/src/tracking-entregadores-resumo.html
@@ -194,6 +194,10 @@
               <div class="form-control form-control-readonly" id="fech-periodo-display">—</div>
             </div>
             <div class="mb-3">
+              <label class="form-label form-label-modal">Código do fechamento</label>
+              <div class="form-control form-control-readonly" id="fech-codigo">—</div>
+            </div>
+            <div class="mb-3">
               <label class="form-label form-label-modal">Valor base (saídas)</label>
               <input type="text" id="fech-valor-base" class="form-control form-control-readonly" readonly>
             </div>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -40,7 +40,7 @@
                   <div class="dropdown">
                     <button class="btn btn-soft-primary dropdown-toggle d-flex align-items-center gap-2" type="button" id="registros-period-btn" data-bs-toggle="dropdown" data-bs-auto-close="outside">
                       <i class="bx bx-calendar"></i>
-                      <span id="registros-period-label" class="text-truncate">Hoje - 30 dias</span>
+                      <span id="registros-period-label" class="text-truncate">Hoje - 90 dias</span>
                     </button>
                     <div class="dropdown-menu dropdown-menu-end p-0" id="registros-period-panel" style="min-width: 640px;">
                       <input type="hidden" id="flt-from" />

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -144,15 +144,19 @@
                               <div id="flt-acao-toggle" class="filtro-switch-list d-flex flex-column gap-1">
                                 <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-lido" value="lido" checked>
-                                  <label class="form-check-label small" for="flt-acao-lido">Lido</label>
+                                  <label class="form-check-label small" for="flt-acao-lido">Leu pedido</label>
                                 </div>
                                 <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-scan" value="scan" checked>
-                                  <label class="form-check-label small" for="flt-acao-scan">Scan</label>
+                                  <label class="form-check-label small" for="flt-acao-scan">Escaneou pedido</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-assumir" value="assumir" checked>
-                                  <label class="form-check-label small" for="flt-acao-assumir">Reatribuido</label>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-reatribuido" value="reatribuido" checked>
+                                  <label class="form-check-label small" for="flt-acao-reatribuido">Reatribuiu pedido</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-reatribuido-em-rota" value="reatribuido_em_rota" checked>
+                                  <label class="form-check-label small" for="flt-acao-reatribuido-em-rota">Reatribuído -> Iniciou rota</label>
                                 </div>
                                 <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-em-rota" value="em_rota" checked>
@@ -160,19 +164,19 @@
                                 </div>
                                 <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-entregue" value="entregue" checked>
-                                  <label class="form-check-label small" for="flt-acao-entregue">Entregue</label>
+                                  <label class="form-check-label small" for="flt-acao-entregue">Finalizou entrega</label>
                                 </div>
                                 <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-ausente" value="ausente" checked>
-                                  <label class="form-check-label small" for="flt-acao-ausente">Ausente</label>
+                                  <label class="form-check-label small" for="flt-acao-ausente">Registrou ausência</label>
                                 </div>
                                 <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-cancelado" value="cancelado" checked>
-                                  <label class="form-check-label small" for="flt-acao-cancelado">Cancelado</label>
+                                  <label class="form-check-label small" for="flt-acao-cancelado">Registrou cancelamento</label>
                                 </div>
                                 <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-desatribuido" value="desatribuido" checked>
-                                  <label class="form-check-label small" for="flt-acao-desatribuido">Desatribuido</label>
+                                  <label class="form-check-label small" for="flt-acao-desatribuido">Desatribuiu pedido</label>
                                 </div>
                               </div>
                             </div>
@@ -316,6 +320,7 @@
                     <tr>
                       <th style="width:40px;"></th>
                       <th style="width:36px"><input id="chk-all" type="checkbox" class="form-check-input" /></th>
+                      <th>Data/Hora entrada</th>
                       <th>Data/Hora ação</th>
                       <th data-owner-term="base">Base</th>
                       <th>Lido por</th>
@@ -328,7 +333,7 @@
                     </tr>
                   </thead>
                   <tbody id="reg-rows">
-                    <tr><td colspan="11" class="text-center text-muted py-4">Carregando...</td></tr>
+                    <tr><td colspan="12" class="text-center text-muted py-4">Carregando...</td></tr>
                   </tbody>
                 </table>
               </div>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -75,13 +75,19 @@
                           </h2>
                           <div id="collapseServico" class="accordion-collapse collapse" aria-labelledby="headingServico" data-bs-parent="#filtrosAccordion">
                             <div class="accordion-body pt-2 pb-1">
-                              <div id="flt-servico-toggle" class="d-flex flex-wrap gap-1">
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-shopee" value="Shopee" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-servico-shopee">Shopee</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-ml" value="Mercado Livre" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-servico-ml">Mercado Livre</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-avulso" value="Avulso" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-servico-avulso">Avulso</label>
+                              <div id="flt-servico-toggle" class="filtro-switch-list d-flex flex-column gap-1">
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-servico-shopee" value="Shopee" checked>
+                                  <label class="form-check-label small" for="flt-servico-shopee">Shopee</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-servico-ml" value="Mercado Livre" checked>
+                                  <label class="form-check-label small" for="flt-servico-ml">Mercado Livre</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-servico-avulso" value="Avulso" checked>
+                                  <label class="form-check-label small" for="flt-servico-avulso">Avulso</label>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -94,21 +100,35 @@
                           </h2>
                           <div id="collapseStatus" class="accordion-collapse collapse" aria-labelledby="headingStatus" data-bs-parent="#filtrosAccordion">
                             <div class="accordion-body pt-2 pb-1">
-                              <div id="flt-status-toggle" class="d-flex flex-wrap gap-1">
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-saiu" value="saiu" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-saiu">Saiu para entrega</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-emrota" value="em_rota" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-emrota">Em rota</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-entregue" value="entregue" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-entregue">Entregue</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-ausente" value="ausente" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-ausente">Ausente</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-coletado" value="coletado" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-coletado">Coletado</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-nao-coletado" value="nao_coletado" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-nao-coletado">Não Coletado</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-cancelado" value="cancelado" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-cancelado">Cancelado</label>
+                              <div id="flt-status-toggle" class="filtro-switch-list d-flex flex-column gap-1">
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-saiu" value="saiu" checked>
+                                  <label class="form-check-label small" for="flt-status-saiu">Saiu para entrega</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-emrota" value="em_rota" checked>
+                                  <label class="form-check-label small" for="flt-status-emrota">Em rota</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-entregue" value="entregue" checked>
+                                  <label class="form-check-label small" for="flt-status-entregue">Entregue</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-ausente" value="ausente" checked>
+                                  <label class="form-check-label small" for="flt-status-ausente">Ausente</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-coletado" value="coletado" checked>
+                                  <label class="form-check-label small" for="flt-status-coletado">Coletado</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-nao-coletado" value="nao_coletado" checked>
+                                  <label class="form-check-label small" for="flt-status-nao-coletado">Não Coletado</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-cancelado" value="cancelado" checked>
+                                  <label class="form-check-label small" for="flt-status-cancelado">Cancelado</label>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -121,23 +141,39 @@
                           </h2>
                           <div id="collapseAcao" class="accordion-collapse collapse" aria-labelledby="headingAcao" data-bs-parent="#filtrosAccordion">
                             <div class="accordion-body pt-2 pb-1">
-                              <div id="flt-acao-toggle" class="d-flex flex-wrap gap-1">
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-lido" value="lido" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-lido">Lido</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-scan" value="scan" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-scan">Scan</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-assumir" value="assumir" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-assumir">Reatribuido</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-em-rota" value="em_rota" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-em-rota">Iniciou rota</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-entregue" value="entregue" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-entregue">Entregue</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-ausente" value="ausente" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-ausente">Ausente</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-cancelado" value="cancelado" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-cancelado">Cancelado</label>
-                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-desatribuido" value="desatribuido" checked>
-                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-desatribuido">Desatribuido</label>
+                              <div id="flt-acao-toggle" class="filtro-switch-list d-flex flex-column gap-1">
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-lido" value="lido" checked>
+                                  <label class="form-check-label small" for="flt-acao-lido">Lido</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-scan" value="scan" checked>
+                                  <label class="form-check-label small" for="flt-acao-scan">Scan</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-assumir" value="assumir" checked>
+                                  <label class="form-check-label small" for="flt-acao-assumir">Reatribuido</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-em-rota" value="em_rota" checked>
+                                  <label class="form-check-label small" for="flt-acao-em-rota">Iniciou rota</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-entregue" value="entregue" checked>
+                                  <label class="form-check-label small" for="flt-acao-entregue">Entregue</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-ausente" value="ausente" checked>
+                                  <label class="form-check-label small" for="flt-acao-ausente">Ausente</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-cancelado" value="cancelado" checked>
+                                  <label class="form-check-label small" for="flt-acao-cancelado">Cancelado</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-desatribuido" value="desatribuido" checked>
+                                  <label class="form-check-label small" for="flt-acao-desatribuido">Desatribuido</label>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -67,26 +67,73 @@
                         </select>
                       </div>
                       <div class="mb-2">
-                        <label class="form-label small">Serviço</label>
-                        <select id="flt-servico" class="form-select form-select-sm">
-                          <option value="">(Todos)</option>
-                          <option value="Shopee">Shopee</option>
-                          <option value="Mercado Livre">Mercado Livre</option>
-                          <option value="Avulso">Avulso</option>
-                        </select>
+                        <label class="form-label small d-block">Serviço</label>
+                        <div id="flt-servico-toggle" class="d-flex flex-wrap gap-1">
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-shopee" value="Shopee" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-servico-shopee">Shopee</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-ml" value="Mercado Livre" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-servico-ml">Mercado Livre</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-avulso" value="Avulso" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-servico-avulso">Avulso</label>
+                        </div>
+                      </div>
+                      <div class="mb-2">
+                        <label class="form-label small d-block">Status</label>
+                        <div id="flt-status-toggle" class="d-flex flex-wrap gap-1">
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-saiu" value="saiu" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-saiu">Saiu para entrega</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-emrota" value="em_rota" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-emrota">Em rota</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-entregue" value="entregue" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-entregue">Entregue</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-ausente" value="ausente" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-ausente">Ausente</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-coletado" value="coletado" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-coletado">Coletado</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-nao-coletado" value="nao_coletado" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-nao-coletado">Não Coletado</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-cancelado" value="cancelado" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-cancelado">Cancelado</label>
+                        </div>
                       </div>
                       <div class="mb-3">
-                        <label class="form-label small">Status</label>
-                        <select id="flt-status" class="form-select form-select-sm">
-                          <option value="">(Todos)</option>
-                          <option value="saiu">Saiu para entrega</option>
-                          <option value="em_rota">Em rota</option>
-                          <option value="entregue">Entregue</option>
-                          <option value="ausente">Ausente</option>
-                          <option value="Coletado">Coletado</option>
-                          <option value="Não Coletado">Não Coletado</option>
-                          <option value="Cancelado">Cancelado</option>
-                        </select>
+                        <label class="form-label small d-block">Ação</label>
+                        <div id="flt-acao-toggle" class="d-flex flex-wrap gap-1">
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-lido" value="lido" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-lido">Lido</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-scan" value="scan" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-scan">Scan</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-assumir" value="assumir" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-assumir">Assumiu entrega</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-reatribuicao" value="reatribuicao" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-reatribuicao">Reatribuido</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-em-rota" value="em_rota" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-em-rota">Iniciou rota</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-entregue" value="entregue" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-entregue">Entregue</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-ausente" value="ausente" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-ausente">Ausente</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-cancelado" value="cancelado" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-cancelado">Cancelado</label>
+
+                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-desatribuido" value="desatribuido" checked>
+                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-desatribuido">Desatribuido</label>
+                        </div>
                       </div>
                       <div class="form-check mb-3">
                         <input class="form-check-input" type="checkbox" id="flt-somente-g">

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -95,7 +95,7 @@
                         <div class="accordion-item">
                           <h2 class="accordion-header" id="headingStatus">
                             <button class="accordion-button collapsed py-2 small" type="button" data-bs-toggle="collapse" data-bs-target="#collapseStatus" aria-expanded="false" aria-controls="collapseStatus">
-                              Status
+                              Situação
                             </button>
                           </h2>
                           <div id="collapseStatus" class="accordion-collapse collapse" aria-labelledby="headingStatus" data-bs-parent="#filtrosAccordion">
@@ -320,15 +320,15 @@
                     <tr>
                       <th style="width:40px;"></th>
                       <th style="width:36px"><input id="chk-all" type="checkbox" class="form-check-input" /></th>
-                      <th>Data/Hora entrada</th>
-                      <th>Data/Hora ação</th>
-                      <th data-owner-term="base">Base</th>
-                      <th>Lido por</th>
-                      <th>Ação</th>
-                      <th>Entregador</th>
-                      <th>Código</th>
-                      <th>Serviço</th>
-                      <th>Status</th>
+                      <th style="min-width:180px;">Código</th>
+                      <th style="min-width:120px;">Serviço</th>
+                      <th style="min-width:120px;">Status</th>
+                      <th style="min-width:160px;">Ação</th>
+                      <th style="min-width:150px;">Entregador</th>
+                      <th style="min-width:160px;">Horário da ação</th>
+                      <th style="min-width:170px;">Entrada no sistema</th>
+                      <th style="min-width:110px;">Lido por</th>
+                      <th style="min-width:110px;">Seller</th>
                       <th class="text-center" style="width:50px" title="Pacote G (Grande)">G</th>
                     </tr>
                   </thead>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -67,72 +67,86 @@
                         </select>
                       </div>
                       <div class="mb-2">
-                        <label class="form-label small d-block">Serviço</label>
-                        <div id="flt-servico-toggle" class="d-flex flex-wrap gap-1">
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-shopee" value="Shopee" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-servico-shopee">Shopee</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-ml" value="Mercado Livre" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-servico-ml">Mercado Livre</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-avulso" value="Avulso" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-servico-avulso">Avulso</label>
+                        <div class="form-check form-switch mb-2">
+                          <input class="form-check-input" type="checkbox" id="flt-multi-toggle">
+                          <label class="form-check-label small" for="flt-multi-toggle">Ativar multi-seleção</label>
                         </div>
                       </div>
-                      <div class="mb-2">
-                        <label class="form-label small d-block">Status</label>
-                        <div id="flt-status-toggle" class="d-flex flex-wrap gap-1">
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-saiu" value="saiu" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-saiu">Saiu para entrega</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-emrota" value="em_rota" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-emrota">Em rota</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-entregue" value="entregue" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-entregue">Entregue</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-ausente" value="ausente" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-ausente">Ausente</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-coletado" value="coletado" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-coletado">Coletado</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-nao-coletado" value="nao_coletado" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-nao-coletado">Não Coletado</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-cancelado" value="cancelado" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-status-cancelado">Cancelado</label>
+                      <div class="accordion accordion-flush mb-3" id="filtrosAccordion">
+                        <div class="accordion-item">
+                          <h2 class="accordion-header" id="headingServico">
+                            <button class="accordion-button collapsed py-2 small" type="button" data-bs-toggle="collapse" data-bs-target="#collapseServico" aria-expanded="false" aria-controls="collapseServico">
+                              Serviço
+                            </button>
+                          </h2>
+                          <div id="collapseServico" class="accordion-collapse collapse" aria-labelledby="headingServico" data-bs-parent="#filtrosAccordion">
+                            <div class="accordion-body pt-2 pb-1">
+                              <div id="flt-servico-toggle" class="d-flex flex-wrap gap-1">
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-shopee" value="Shopee" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-servico-shopee">Shopee</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-ml" value="Mercado Livre" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-servico-ml">Mercado Livre</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-servico-avulso" value="Avulso" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-servico-avulso">Avulso</label>
+                              </div>
+                            </div>
+                          </div>
                         </div>
-                      </div>
-                      <div class="mb-3">
-                        <label class="form-label small d-block">Ação</label>
-                        <div id="flt-acao-toggle" class="d-flex flex-wrap gap-1">
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-lido" value="lido" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-lido">Lido</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-scan" value="scan" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-scan">Scan</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-assumir" value="assumir" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-assumir">Assumiu entrega</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-reatribuicao" value="reatribuicao" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-reatribuicao">Reatribuido</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-em-rota" value="em_rota" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-em-rota">Iniciou rota</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-entregue" value="entregue" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-entregue">Entregue</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-ausente" value="ausente" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-ausente">Ausente</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-cancelado" value="cancelado" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-cancelado">Cancelado</label>
-
-                          <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-desatribuido" value="desatribuido" checked>
-                          <label class="btn btn-sm btn-outline-secondary" for="flt-acao-desatribuido">Desatribuido</label>
+                        <div class="accordion-item">
+                          <h2 class="accordion-header" id="headingStatus">
+                            <button class="accordion-button collapsed py-2 small" type="button" data-bs-toggle="collapse" data-bs-target="#collapseStatus" aria-expanded="false" aria-controls="collapseStatus">
+                              Status
+                            </button>
+                          </h2>
+                          <div id="collapseStatus" class="accordion-collapse collapse" aria-labelledby="headingStatus" data-bs-parent="#filtrosAccordion">
+                            <div class="accordion-body pt-2 pb-1">
+                              <div id="flt-status-toggle" class="d-flex flex-wrap gap-1">
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-saiu" value="saiu" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-saiu">Saiu para entrega</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-emrota" value="em_rota" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-emrota">Em rota</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-entregue" value="entregue" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-entregue">Entregue</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-ausente" value="ausente" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-ausente">Ausente</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-coletado" value="coletado" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-coletado">Coletado</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-nao-coletado" value="nao_coletado" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-nao-coletado">Não Coletado</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-status-cancelado" value="cancelado" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-status-cancelado">Cancelado</label>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="accordion-item">
+                          <h2 class="accordion-header" id="headingAcao">
+                            <button class="accordion-button collapsed py-2 small" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAcao" aria-expanded="false" aria-controls="collapseAcao">
+                              Ação
+                            </button>
+                          </h2>
+                          <div id="collapseAcao" class="accordion-collapse collapse" aria-labelledby="headingAcao" data-bs-parent="#filtrosAccordion">
+                            <div class="accordion-body pt-2 pb-1">
+                              <div id="flt-acao-toggle" class="d-flex flex-wrap gap-1">
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-lido" value="lido" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-lido">Lido</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-scan" value="scan" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-scan">Scan</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-assumir" value="assumir" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-assumir">Reatribuido</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-em-rota" value="em_rota" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-em-rota">Iniciou rota</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-entregue" value="entregue" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-entregue">Entregue</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-ausente" value="ausente" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-ausente">Ausente</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-cancelado" value="cancelado" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-cancelado">Cancelado</label>
+                                <input type="checkbox" class="btn-check filtro-toggle-item" id="flt-acao-desatribuido" value="desatribuido" checked>
+                                <label class="btn btn-sm btn-outline-secondary" for="flt-acao-desatribuido">Desatribuido</label>
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
                       <div class="form-check mb-3">

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -66,12 +66,6 @@
                           <option value="">(Todos)</option>
                         </select>
                       </div>
-                      <div class="mb-2">
-                        <div class="form-check form-switch mb-2">
-                          <input class="form-check-input" type="checkbox" id="flt-multi-toggle">
-                          <label class="form-check-label small" for="flt-multi-toggle">Ativar multi-seleção</label>
-                        </div>
-                      </div>
                       <div class="accordion accordion-flush mb-3" id="filtrosAccordion">
                         <div class="accordion-item">
                           <h2 class="accordion-header" id="headingServico">


### PR DESCRIPTION
## Título
feat: melhora registros e fechamento PDF com filtros operacionais e layout auditável

## Resumo
Este PR evolui a experiência de **Registros** e **Fechamento de Motoboy** no frontend, com foco em clareza operacional, consistência visual e auditabilidade do documento PDF.

As mudanças incluem:
- filtros multi-seleção mais claros e funcionais;
- separação explícita entre data de entrada e data/hora da ação;
- reorganização da tabela de registros;
- refinamento completo do PDF de fechamento (resumo financeiro, seção diária, status, rastreabilidade e destaque de total a pagar);
- ajuste do período padrão de Registros para **d-45**.

## Objetivos atendidos
- Melhorar leitura e análise operacional da tela de Registros.
- Reduzir ambiguidades de status/ação com labels e organização mais claras.
- Tornar o PDF de fechamento mais compacto, auditável e fácil de validar.
- Padronizar apresentação de valores financeiros (sinais e critérios).
- Ajustar preset padrão de período para comportamento mais aderente ao uso real.

## Principais mudanças
- **Registros**
  - Implementação/ajuste de filtros multiseleção de status, serviço e ação.
  - Melhorias de UX com acordeão/toggles visuais.
  - Reorganização das colunas para foco operacional.
  - Exibição separada de:
    - data de entrada no sistema;
    - data/hora da ação operacional.
- **Fechamento (resumo e PDF)**
  - Refinos em layout e paginação.
  - Melhor clareza de cards/indicadores de cancelados.
  - Documento digital com maior rastreabilidade.
  - Padronização de sinais monetários e labels financeiros.
  - Resumo financeiro com linha **TOTAL A PAGAR** destacada.
  - Ajustes condicionais para evitar blocos redundantes.
- **Período padrão**
  - Ajuste de preset em Registros para **hoje - 45 dias**.

## Commits incluídos
- feat: melhora clareza de registros e fechamento com ação, data/hora e cancelados
- fix: ajusta tela de alerta de calculo no fechamento e padroniza card de cancelados
- feat: implenta filtros multiseleção de status, serviço e ação em registros
- feat: melhora UX dos filtros com acordeão e toggle de multi-seleção
- feat: melhora UX dos filtros com acordeão e toggle de multi-seleção
- feat: padroniza filtros de registros com toggles visuais por opção
- feat: exibe data de entrada e data/hora da ação em registros
- feat: reorganiza tabela de registros com foco em leitura operacional
- feat: altera período padrão de registros para hoje menos 90 dias
- feat: melhora documento digital do fechamento de motoboy com rastreabilidade
- refactor: ajusta clareza financeira do PDF de fechamento de motoboy
- fix: compacta layout do PDF de fechamento e corrige paginação
- fix: refina layout do PDF de fechamento com sinais padronizados e resumo financeiro condicional
- fix: destaca linha TOTAL A PAGAR no resumo financeiro do PDF
- fix: ajusta período padrão de Registros para d-45

## Arquivos principais alterados
- `Master/src/tracking-registros.html`
- `Master/src/assets/js/pages/tracking-registros.init.js`
- `Master/src/assets/js/pages/tracking-api-leitura-registros.init.js`
- `Master/src/assets/js/components/date-picker-dashboard.js`
- `Master/src/tracking-entregadores-resumo.html`
- `Master/src/assets/js/pages/tracking-entregadores-resumo.init.js`
- `Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js`
- `Master/src/assets/scss/custom.scss`

## Labels sugeridas
- `feature`
- `fix`
- `refactor`

## Riscos
- Alterações amplas na renderização de Registros podem afetar comportamento de filtros em combinações específicas.
- Ajustes grandes no gerador de PDF podem gerar diferença visual entre navegadores/impressoras.
- Mudanças de preset de período podem impactar expectativa de usuários acostumados ao intervalo anterior.

## Mitigações
- Preservação da estrutura de consumo da API e adaptação progressiva na normalização de dados da tabela.
- Melhorias incrementais e commits temáticos em etapas (UX, tabela, PDF, período).
- Seções financeiras do PDF com regras explícitas e sinais padronizados para reduzir ambiguidade.

## Como testar
### 1) Registros
- Abrir tela e validar carregamento padrão em **Hoje - 45 dias**.
- Validar filtros multiseleção (status, serviço, ação), com combinações múltiplas.
- Confirmar ordenação/visual das colunas:
  - código, serviço, status, ação, entregador, horário da ação, entrada no sistema, etc.
- Confirmar que data de entrada e data/hora de ação aparecem separadamente e corretas.

### 2) Fechamento (tela resumo)
- Validar cards e alertas de cálculo/cancelados.
- Conferir consistência de totais com cenários de cancelamento, ajustes e pacotes grandes.

### 3) PDF de fechamento
- Gerar PDF para cenários:
  - com e sem pacotes G;
  - com e sem cancelados;
  - com ajustes manuais.
- Validar:
  - status e identificação do fechamento;
  - seção diária e resumo financeiro;
  - padronização de sinais (`+/-`);
  - destaque visual da linha **TOTAL A PAGAR**;
  - quebra de página e legibilidade geral.

## Observações
- O branch contém evolução incremental (incluindo transição de d-90 para d-45); o estado final esperado é **d-45**.