### PR TITLE
fix: padroniza ordenação alfabética de motoboys e entregadores em fil…

### DIFF
--- a/Master/src/assets/js/pages/tracking-acompanhamento.init.js
+++ b/Master/src/assets/js/pages/tracking-acompanhamento.init.js
@@ -136,7 +136,14 @@
     if (!select) return;
     try {
       const list = await fetchWithCreds(API_MOTOBOYS);
-      const opts = (list || []).map((m) => {
+      const sorted = (Array.isArray(list) ? list : []).slice().sort((a, b) => {
+        const va = a?.id_motoboy != null ? a.id_motoboy : a?.id;
+        const vb = b?.id_motoboy != null ? b.id_motoboy : b?.id;
+        const la = String(a?.nome || `Motoboy ${va || ""}`);
+        const lb = String(b?.nome || `Motoboy ${vb || ""}`);
+        return la.localeCompare(lb, "pt-BR", { sensitivity: "base" });
+      });
+      const opts = sorted.map((m) => {
         const val = m.id_motoboy != null ? m.id_motoboy : m.id;
         const label = m.nome || `Motoboy ${val}`;
         return `<option value="${escapeHtml(String(val))}">${escapeHtml(label)}</option>`;

--- a/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
@@ -781,7 +781,11 @@ document.addEventListener("DOMContentLoaded", async () => {
       const res = await fetch(`${API_ENTREGADORES}/executores?status=ativo`, { credentials: "include" });
       if (!res.ok) return;
       const list = await res.json();
-      const arr = Array.isArray(list) ? list : [];
+      const arr = (Array.isArray(list) ? list : []).slice().sort((a, b) => {
+        const na = String(a?.nome || a?.executor_key || "").localeCompare(String(b?.nome || b?.executor_key || ""), "pt-BR", { sensitivity: "base" });
+        if (na !== 0) return na;
+        return String(a?.executor_key || "").localeCompare(String(b?.executor_key || ""), "pt-BR", { sensitivity: "base" });
+      });
       const opts = arr.map((e) => {
         const val = e.executor_key || (e.id_motoboy != null ? "m_" + e.id_motoboy : "e_" + e.id_entregador);
         const nome = (e.nome || val).replace(/</g, "&lt;").replace(/"/g, "&quot;");

--- a/Master/src/assets/js/pages/tracking-valores-entrega.init.js
+++ b/Master/src/assets/js/pages/tracking-valores-entrega.init.js
@@ -192,9 +192,12 @@
       const select = qs("#selectEntregador");
       if (!select) return;
       const idsComExcecao = CACHE_EXCECÕES.map((e) => e.entregador_id);
+      const ordenados = arr
+        .filter((e) => !idsComExcecao.includes(e.id_entregador))
+        .slice()
+        .sort((a, b) => String(a?.nome || a?.id_entregador || "").localeCompare(String(b?.nome || b?.id_entregador || ""), "pt-BR", { sensitivity: "base" }));
       select.innerHTML = '<option value="">Selecione o entregador</option>' +
-        arr
-          .filter((e) => !idsComExcecao.includes(e.id_entregador))
+        ordenados
           .map((e) => `<option value="${e.id_entregador}">${e.nome || e.id_entregador}</option>`)
           .join("");
     } catch (err) {


### PR DESCRIPTION
fix: padroniza ordenação alfabética de motoboys e entregadores em filtros e selects

## Resumo

Padroniza a ordenação alfabética (pt-BR) das listas de motoboys/entregadores em telas de seleção e filtros no frontend, garantindo consistência visual entre páginas sem alterar regras de negócio.

## Tipo de alteração

- [ ] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [x] refactor
- [ ] breaking-change

## O que foi feito

- Aplicada ordenação alfabética em `tracking-entregadores-resumo.init.js` para lista de executores.
- Aplicada ordenação alfabética em `tracking-acompanhamento.init.js` para filtro de motoboy.
- Aplicada ordenação alfabética em `tracking-valores-entrega.init.js` para select de entregador.
- Confirmado que telas como Registros, Leitura e Coleta Leitura já possuíam ordenação e foram mantidas.

## Como testar

- Fechamento de motoboys: abrir filtro de executor e conferir ordem alfabética.
- Acompanhamento: abrir filtro de motoboy e conferir ordem alfabética.
- Valores de entrega: abrir select de entregador e conferir ordem alfabética.
- Registros/Leitura/Coleta Leitura: validar que continuam com ordenação correta.

## Impacto

- [x] Sem impacto em produção
- [ ] Altera comportamento existente
- [x] Altera layout/interface
- [ ] Altera integração com backend/API
- [ ] Requer configuração adicional
- [ ] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [ ] Conferi se a alteração depende de backend