### PR TITLE
fix: atualiza toggle de indicadores para modo operacional

### DIFF
--- a/Master/src/assets/js/pages/dashboard-admin.init.js
+++ b/Master/src/assets/js/pages/dashboard-admin.init.js
@@ -229,7 +229,7 @@
     updatePeriodLabel(hoje.start, hoje.end);
 
     function syncAdminIndicadorToggleUI() {
-      var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "saiu";
+      var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "operacional";
       var group = document.getElementById("admin-indicador-status-mode-group");
       if (!group) return;
       group.querySelectorAll("button[data-mode]").forEach(function (b) {
@@ -245,7 +245,7 @@
         var btn = ev.target && ev.target.closest && ev.target.closest("button[data-mode]");
         if (!btn) return;
         var mode = btn.getAttribute("data-mode");
-        if (mode !== "saiu" && mode !== "entregue") return;
+        if (mode !== "saiu" && mode !== "operacional" && mode !== "entregue") return;
         if (window.TrackPrefs && window.TrackPrefs.setIndicadorStatusMode) window.TrackPrefs.setIndicadorStatusMode(mode);
         syncAdminIndicadorToggleUI();
         load();

--- a/Master/src/assets/js/pages/dashboard-coletas.init.js
+++ b/Master/src/assets/js/pages/dashboard-coletas.init.js
@@ -477,7 +477,7 @@
     updatePeriodLabel(today, today);
 
     function syncColetasIndicadorToggleUI() {
-      var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "saiu";
+      var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "operacional";
       var group = document.getElementById("coletas-indicador-status-mode-group");
       if (!group) return;
       group.querySelectorAll("button[data-mode]").forEach(function (b) {
@@ -493,7 +493,7 @@
         var btn = ev.target && ev.target.closest && ev.target.closest("button[data-mode]");
         if (!btn) return;
         var mode = btn.getAttribute("data-mode");
-        if (mode !== "saiu" && mode !== "entregue") return;
+        if (mode !== "saiu" && mode !== "operacional" && mode !== "entregue") return;
         if (window.TrackPrefs && window.TrackPrefs.setIndicadorStatusMode) window.TrackPrefs.setIndicadorStatusMode(mode);
         syncColetasIndicadorToggleUI();
         load();

--- a/Master/src/assets/js/pages/dashboard-financeiro.init.js
+++ b/Master/src/assets/js/pages/dashboard-financeiro.init.js
@@ -74,7 +74,7 @@
   }
 
   function syncFinIndicadorToggleUI() {
-    var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "saiu";
+    var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "operacional";
     var group = document.getElementById("fin-indicador-status-mode-group");
     if (!group) return;
     group.querySelectorAll("button[data-mode]").forEach(function (b) {
@@ -104,7 +104,7 @@
     const params = new URLSearchParams();
     params.set("data_inicio", from);
     params.set("data_fim", to);
-    var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "saiu";
+    var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "operacional";
     params.set("modo_entregas", modo);
     return fetchJson(API_BASE + "/contabilidade/resumo?" + params.toString());
   }
@@ -370,7 +370,7 @@
         var btn = ev.target && ev.target.closest && ev.target.closest("button[data-mode]");
         if (!btn) return;
         var mode = btn.getAttribute("data-mode");
-        if (mode !== "saiu" && mode !== "entregue") return;
+        if (mode !== "saiu" && mode !== "operacional" && mode !== "entregue") return;
         if (window.TrackPrefs && window.TrackPrefs.setIndicadorStatusMode) window.TrackPrefs.setIndicadorStatusMode(mode);
         syncFinIndicadorToggleUI();
         load();

--- a/Master/src/assets/js/pages/dashboard-saidas.init.js
+++ b/Master/src/assets/js/pages/dashboard-saidas.init.js
@@ -71,6 +71,8 @@
     const params = new URLSearchParams();
     if (from) params.set("data_inicio", from);
     if (to) params.set("data_fim", to);
+    var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "operacional";
+    params.set("modo_entregas", modo);
     return fetchJson(API_BASE + "/dashboard/saidas?" + params.toString());
   }
 
@@ -257,7 +259,7 @@
     updatePeriodLabel(today, today);
 
     function syncSaidasIndicadorToggleUI() {
-      var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "saiu";
+      var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "operacional";
       var group = document.getElementById("saidas-indicador-status-mode-group");
       if (!group) return;
       group.querySelectorAll("button[data-mode]").forEach(function (b) {
@@ -273,7 +275,7 @@
         var btn = ev.target && ev.target.closest && ev.target.closest("button[data-mode]");
         if (!btn) return;
         var mode = btn.getAttribute("data-mode");
-        if (mode !== "saiu" && mode !== "entregue") return;
+        if (mode !== "saiu" && mode !== "operacional" && mode !== "entregue") return;
         if (window.TrackPrefs && window.TrackPrefs.setIndicadorStatusMode) window.TrackPrefs.setIndicadorStatusMode(mode);
         syncSaidasIndicadorToggleUI();
         load();

--- a/Master/src/assets/js/pages/dashboard-visao-360.init.js
+++ b/Master/src/assets/js/pages/dashboard-visao-360.init.js
@@ -509,7 +509,7 @@
     updatePeriodLabel(today, today);
 
     function syncVisao360IndicadorToggleUI() {
-      var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "saiu";
+      var modo = (window.TrackPrefs && window.TrackPrefs.getIndicadorStatusMode && window.TrackPrefs.getIndicadorStatusMode()) || "operacional";
       var group = document.getElementById("visao360-indicador-status-mode-group");
       if (!group) return;
       group.querySelectorAll("button[data-mode]").forEach(function (b) {
@@ -525,7 +525,7 @@
         var btn = ev.target && ev.target.closest && ev.target.closest("button[data-mode]");
         if (!btn) return;
         var mode = btn.getAttribute("data-mode");
-        if (mode !== "saiu" && mode !== "entregue") return;
+        if (mode !== "saiu" && mode !== "operacional" && mode !== "entregue") return;
         if (window.TrackPrefs && window.TrackPrefs.setIndicadorStatusMode) window.TrackPrefs.setIndicadorStatusMode(mode);
         syncVisao360IndicadorToggleUI();
         load();

--- a/Master/src/assets/js/user-preferences.js
+++ b/Master/src/assets/js/user-preferences.js
@@ -1,24 +1,26 @@
 /**
  * Preferências de usuário (TrackPrefs) — persistidas em localStorage.
- * Usado para o modo de indicadores: "saiu para entrega" vs "entregue" (app mobile).
+ * Usado para o modo de indicadores: "operacional" (status válidos) vs "entregue" (app mobile).
  */
 (function () {
   "use strict";
 
   const STORAGE_KEY = "track_indicadores_status_mode";
-  const VALID_MODES = ["saiu", "entregue"];
+  const VALID_MODES = ["saiu", "operacional", "entregue"];
 
   function getIndicadorStatusMode() {
     try {
-      const v = (localStorage.getItem(STORAGE_KEY) || "saiu").trim().toLowerCase();
-      return VALID_MODES.includes(v) ? v : "saiu";
+      const raw = (localStorage.getItem(STORAGE_KEY) || "operacional").trim().toLowerCase();
+      // Migração de preferência antiga: "saiu" passa a "operacional"
+      const v = raw === "saiu" ? "operacional" : raw;
+      return VALID_MODES.includes(v) ? v : "operacional";
     } catch (_) {
-      return "saiu";
+      return "operacional";
     }
   }
 
   function setIndicadorStatusMode(mode) {
-    const m = (mode || "saiu").trim().toLowerCase();
+    const m = (mode || "operacional").trim().toLowerCase();
     if (!VALID_MODES.includes(m)) return;
     try {
       localStorage.setItem(STORAGE_KEY, m);

--- a/Master/src/dashboard-admin.html
+++ b/Master/src/dashboard-admin.html
@@ -39,7 +39,7 @@
                 <div class="d-flex align-items-center gap-2 mt-2 flex-wrap">
                   <span class="text-muted small">Indicadores de entrega:</span>
                   <div id="admin-indicador-status-mode-group" class="btn-group btn-group-sm" role="group">
-                    <button type="button" class="btn btn-outline-secondary" data-mode="saiu" title="Contar como entregue quando registrou saiu para entrega">Saiu para entrega</button>
+                    <button type="button" class="btn btn-outline-secondary" data-mode="operacional" title="Contar status operacionais válidos (saiu/em rota/entregue/ausente...)">Operacional</button>
                     <button type="button" class="btn btn-outline-secondary" data-mode="entregue" title="Contar apenas status Entregue (app mobile)">Entregue (app)</button>
                   </div>
                 </div>

--- a/Master/src/dashboard-coletas.html
+++ b/Master/src/dashboard-coletas.html
@@ -42,7 +42,7 @@
                 <div class="d-flex align-items-center gap-2 mt-2 flex-wrap">
                   <span class="text-muted small">Indicadores de entrega:</span>
                   <div id="coletas-indicador-status-mode-group" class="btn-group btn-group-sm" role="group">
-                    <button type="button" class="btn btn-outline-secondary" data-mode="saiu" title="Contar como entregue quando registrou saiu para entrega">Saiu para entrega</button>
+                    <button type="button" class="btn btn-outline-secondary" data-mode="operacional" title="Contar status operacionais válidos (saiu/em rota/entregue/ausente...)">Operacional</button>
                     <button type="button" class="btn btn-outline-secondary" data-mode="entregue" title="Contar apenas status Entregue (app mobile)">Entregue (app)</button>
                   </div>
                 </div>

--- a/Master/src/dashboard-financeiro.html
+++ b/Master/src/dashboard-financeiro.html
@@ -39,7 +39,7 @@
                 <div class="d-flex align-items-center gap-2 mt-2 flex-wrap">
                   <span class="text-muted small">Indicadores de entrega:</span>
                   <div id="fin-indicador-status-mode-group" class="btn-group btn-group-sm" role="group">
-                    <button type="button" class="btn btn-outline-secondary" data-mode="saiu" title="Contar como entregue quando registrou saiu para entrega">Saiu para entrega</button>
+                    <button type="button" class="btn btn-outline-secondary" data-mode="operacional" title="Contar status operacionais válidos (saiu/em rota/entregue/ausente...)">Operacional</button>
                     <button type="button" class="btn btn-outline-secondary" data-mode="entregue" title="Contar apenas status Entregue (app mobile)">Entregue (app)</button>
                   </div>
                 </div>

--- a/Master/src/dashboard-saidas.html
+++ b/Master/src/dashboard-saidas.html
@@ -39,7 +39,7 @@
                 <div class="d-flex align-items-center gap-2 mt-2 flex-wrap">
                   <span class="text-muted small">Indicadores de entrega:</span>
                   <div id="saidas-indicador-status-mode-group" class="btn-group btn-group-sm" role="group">
-                    <button type="button" class="btn btn-outline-secondary" data-mode="saiu" title="Contar como entregue quando registrou saiu para entrega">Saiu para entrega</button>
+                    <button type="button" class="btn btn-outline-secondary" data-mode="operacional" title="Contar status operacionais válidos (saiu/em rota/entregue/ausente...)">Operacional</button>
                     <button type="button" class="btn btn-outline-secondary" data-mode="entregue" title="Contar apenas status Entregue (app mobile)">Entregue (app)</button>
                   </div>
                 </div>

--- a/Master/src/dashboard-visao-360.html
+++ b/Master/src/dashboard-visao-360.html
@@ -31,7 +31,7 @@
                 <div class="d-flex align-items-center gap-2 mt-2 flex-wrap">
                   <span class="text-muted small">Indicadores de entrega:</span>
                   <div id="visao360-indicador-status-mode-group" class="btn-group btn-group-sm" role="group">
-                    <button type="button" class="btn btn-outline-secondary" data-mode="saiu" title="Contar como entregue quando registrou saiu para entrega">Saiu para entrega</button>
+                    <button type="button" class="btn btn-outline-secondary" data-mode="operacional" title="Contar status operacionais válidos (saiu/em rota/entregue/ausente...)">Operacional</button>
                     <button type="button" class="btn btn-outline-secondary" data-mode="entregue" title="Contar apenas status Entregue (app mobile)">Entregue (app)</button>
                   </div>
                 </div>


### PR DESCRIPTION
## PR Frontend — `track_saidas_html`

Padroniza a contagem dos indicadores de Financeiro e Saídas para usar os mesmos status operacionais válidos já aplicados em Registros e Fechamentos. Também adiciona suporte explícito ao modo operacional no parâmetro modo_entregas, reduzindo divergências de quantidade entre telas.

## Resumo

Atualizada a interface dos dashboards para usar `operacional` como modo padrão de indicadores de entrega, mantendo `entregue` como visão restrita. Também foi garantido o envio correto de `modo_entregas` e adicionada migração da preferência antiga salva como `saiu`.

## Tipo de alteração

- [ ] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Atualizados botões de modo em `dashboard-financeiro.html`, `dashboard-saidas.html`, `dashboard-admin.html`, `dashboard-coletas.html` e `dashboard-visao-360.html` para usar `Operacional`.
- Ajustados scripts `dashboard-*.init.js` para aceitar `operacional` e `entregue`, com fallback padrão em `operacional`.
- Atualizado `user-preferences.js` com migração automática de valor antigo `saiu` para `operacional`.

## Como testar

- Acessar os dashboards e validar os botões `Operacional` e `Entregue (app)` em todas as páginas.
- Alternar o modo, atualizar a página e confirmar persistência da preferência.
- Verificar nas requisições que `modo_entregas` está sendo enviado corretamente (especialmente em Saídas e Financeiro).

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend