### PR TITLE
fix: inclui ação de nova saída no filtro de registros

### DIFF
--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -179,6 +179,10 @@
                                   <label class="form-check-label small" for="flt-acao-cancelado">Registrou cancelamento</label>
                                 </div>
                                 <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-nova-saida-mesmo-entregador" value="nova_saida_mesmo_entregador" checked>
+                                  <label class="form-check-label small" for="flt-acao-nova-saida-mesmo-entregador">Nova saída confirmada (mesmo motoboy)</label>
+                                </div>
+                                <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-desatribuido" value="desatribuido" checked>
                                   <label class="form-check-label small" for="flt-acao-desatribuido">Desatribuiu pedido</label>
                                 </div>


### PR DESCRIPTION
## Resumo

Corrige a tela de Registros para exibir pedidos confirmados no novo fluxo de "nova saída no mesmo motoboy", adicionando essa ação aos filtros de Ação da interface.

## Tipo de alteração

- [ ] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Adicionada a opção de ação `nova_saida_mesmo_entregador` no bloco de filtros de Ação em Registros.
- Incluído o rótulo visual "Nova saída confirmada (mesmo motoboy)" na UI para essa ação.
- Garantido que, com os filtros padrão marcados, registros desse novo fluxo não sejam ocultados.

## Como testar

- Escanear no mobile um pedido já lido em data anterior e confirmar "Confirmar saída hoje".
- Abrir a tela de Registros no frontend e validar que o pedido aparece na listagem.
- No filtro de Ação, marcar/desmarcar "Nova saída confirmada (mesmo motoboy)" e confirmar o comportamento esperado da listagem.

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [ ] Altera integração com backend/API
- [ ] Requer configuração adicional
- [ ] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend