### PR TITLE
feat: melhora UX dos filtros de registros com seleção opt-in

### DIFF
--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1526,15 +1526,12 @@ function setupPagerEvents() {
     let n = 0;
     if ((document.getElementById("flt-base")?.value || "").trim()) n++;
     if ((f.entregador?.value || "").trim()) n++;
-    var totalServico = (f.servicoToggles || []).length;
-    var totalStatus = (f.statusToggles || []).length;
-    var totalAcao = (f.acaoToggles || []).length;
     var ativosServico = (f.servicoToggles || []).filter(el => el.checked).length;
     var ativosStatus = (f.statusToggles || []).filter(el => el.checked).length;
     var ativosAcao = (f.acaoToggles || []).filter(el => el.checked).length;
-    if (totalServico > 0 && ativosServico !== totalServico) n++;
-    if (totalStatus > 0 && ativosStatus !== totalStatus) n++;
-    if (totalAcao > 0 && ativosAcao !== totalAcao) n++;
+    if (ativosServico > 0) n++;
+    if (ativosStatus > 0) n++;
+    if (ativosAcao > 0) n++;
     if (f.somenteG?.checked) n++;
     if (n > 0) {
       filtrosContadorEl.textContent = String(n);
@@ -1566,7 +1563,7 @@ function setupPagerEvents() {
       const fltBase = document.getElementById("flt-base");
       if (fltBase) fltBase.value = "";
       if (f.entregador) f.entregador.value = "";
-      ativarTodosFiltros();
+      limparFiltrosSelecao();
       if (f.somenteG) f.somenteG.checked = false;
       if (datePickerInstance && datePickerInstance.applyPreset) {
         datePickerInstance.applyPreset("ultimos30");
@@ -1587,31 +1584,17 @@ function setupPagerEvents() {
       .concat(f.servicoToggles || [])
       .concat(f.statusToggles || [])
       .concat(f.acaoToggles || []);
-    function aplicarModo(){
-      var grupos = [f.servicoToggles || [], f.statusToggles || [], f.acaoToggles || []];
-      grupos.forEach(function(grupo){
-        if (grupo.length && !grupo.some(el => el.checked)) {
-          grupo[0].checked = true;
-        }
-      });
-    }
     toggles.forEach(function(el){
       el.addEventListener("change", function(){
-        var parent = el.closest("#flt-servico-toggle, #flt-status-toggle, #flt-acao-toggle");
-        if (!parent) return;
-        var grupo = qsa("input.filtro-toggle-item", parent);
-        if (grupo.length && !grupo.some(function(item){ return item.checked; })) {
-          el.checked = true;
-        }
+        atualizarContadorFiltros();
       });
     });
-    aplicarModo();
   }
 
-  function ativarTodosFiltros(){
-    (f.servicoToggles || []).forEach(el => { el.checked = true; });
-    (f.statusToggles || []).forEach(el => { el.checked = true; });
-    (f.acaoToggles || []).forEach(el => { el.checked = true; });
+  function limparFiltrosSelecao(){
+    (f.servicoToggles || []).forEach(el => { el.checked = false; });
+    (f.statusToggles || []).forEach(el => { el.checked = false; });
+    (f.acaoToggles || []).forEach(el => { el.checked = false; });
   }
   if (btnFiltroCancelar) {
     btnFiltroCancelar.onclick = fecharDropdownFiltros;
@@ -1631,7 +1614,7 @@ function setupPagerEvents() {
       fillEntregadores(unicos);
     })
     .finally(() => {
-      ativarTodosFiltros();
+      limparFiltrosSelecao();
       if (f.pageSize) f.pageSize.value = String(state.pageSize);
       refresh(false);
       updateEditButtonState();

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -81,15 +81,15 @@
                             <div class="accordion-body pt-2 pb-1">
                               <div id="flt-servico-toggle" class="filtro-switch-list d-flex flex-column gap-1">
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-servico-shopee" value="Shopee" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-servico-shopee" value="Shopee">
                                   <label class="form-check-label small" for="flt-servico-shopee">Shopee</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-servico-ml" value="Mercado Livre" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-servico-ml" value="Mercado Livre">
                                   <label class="form-check-label small" for="flt-servico-ml">Mercado Livre</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-servico-avulso" value="Avulso" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-servico-avulso" value="Avulso">
                                   <label class="form-check-label small" for="flt-servico-avulso">Avulso</label>
                                 </div>
                               </div>
@@ -106,31 +106,31 @@
                             <div class="accordion-body pt-2 pb-1">
                               <div id="flt-status-toggle" class="filtro-switch-list d-flex flex-column gap-1">
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-saiu" value="saiu" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-saiu" value="saiu">
                                   <label class="form-check-label small" for="flt-status-saiu">Saiu para entrega</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-emrota" value="em_rota" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-emrota" value="em_rota">
                                   <label class="form-check-label small" for="flt-status-emrota">Em rota</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-entregue" value="entregue" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-entregue" value="entregue">
                                   <label class="form-check-label small" for="flt-status-entregue">Entregue</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-ausente" value="ausente" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-ausente" value="ausente">
                                   <label class="form-check-label small" for="flt-status-ausente">Ausente</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-coletado" value="coletado" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-coletado" value="coletado">
                                   <label class="form-check-label small" for="flt-status-coletado">Coletado</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-nao-coletado" value="nao_coletado" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-nao-coletado" value="nao_coletado">
                                   <label class="form-check-label small" for="flt-status-nao-coletado">Não Coletado</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-cancelado" value="cancelado" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-cancelado" value="cancelado">
                                   <label class="form-check-label small" for="flt-status-cancelado">Cancelado</label>
                                 </div>
                               </div>
@@ -147,43 +147,43 @@
                             <div class="accordion-body pt-2 pb-1">
                               <div id="flt-acao-toggle" class="filtro-switch-list d-flex flex-column gap-1">
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-lido" value="lido" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-lido" value="lido">
                                   <label class="form-check-label small" for="flt-acao-lido">Leu pedido</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-scan" value="scan" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-scan" value="scan">
                                   <label class="form-check-label small" for="flt-acao-scan">Escaneou pedido</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-reatribuido" value="reatribuido" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-reatribuido" value="reatribuido">
                                   <label class="form-check-label small" for="flt-acao-reatribuido">Reatribuiu pedido</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-reatribuido-em-rota" value="reatribuido_em_rota" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-reatribuido-em-rota" value="reatribuido_em_rota">
                                   <label class="form-check-label small" for="flt-acao-reatribuido-em-rota">Reatribuído -> Iniciou rota</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-em-rota" value="em_rota" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-em-rota" value="em_rota">
                                   <label class="form-check-label small" for="flt-acao-em-rota">Iniciou rota</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-entregue" value="entregue" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-entregue" value="entregue">
                                   <label class="form-check-label small" for="flt-acao-entregue">Finalizou entrega</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-ausente" value="ausente" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-ausente" value="ausente">
                                   <label class="form-check-label small" for="flt-acao-ausente">Registrou ausência</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-cancelado" value="cancelado" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-cancelado" value="cancelado">
                                   <label class="form-check-label small" for="flt-acao-cancelado">Registrou cancelamento</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-nova-saida-mesmo-entregador" value="nova_saida_mesmo_entregador" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-nova-saida-mesmo-entregador" value="nova_saida_mesmo_entregador">
                                   <label class="form-check-label small" for="flt-acao-nova-saida-mesmo-entregador">Nova saída confirmada (mesmo motoboy)</label>
                                 </div>
                                 <div class="form-check form-switch">
-                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-desatribuido" value="desatribuido" checked>
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-desatribuido" value="desatribuido">
                                   <label class="form-check-label small" for="flt-acao-desatribuido">Desatribuiu pedido</label>
                                 </div>
                               </div>


### PR DESCRIPTION
## Resumo

Melhoria de UX na tela de Registros para tornar os filtros de `Serviço`, `Situação` e `Ação` opt-in: a tela inicia com esses filtros desmarcados, permitindo que o usuário selecione apenas o que deseja filtrar.

## Tipo de alteração

- [x] feature
- [ ] bug
- [ ] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Removido o estado inicial marcado (`checked`) dos filtros de `Serviço`, `Situação` e `Ação` na tela de Registros.
- Ajustada a inicialização para não forçar marcação automática dos filtros e permitir grupos totalmente desmarcados.
- Atualizados os comportamentos de `Limpar` (volta para tudo desmarcado) e do contador de filtros para refletir o novo padrão.

## Como testar

- Abrir a tela de Registros e validar que `Serviço`, `Situação` e `Ação` iniciam com todos os itens desmarcados.
- Clicar em `Aplicar` sem selecionar itens desses grupos e confirmar que a listagem retorna sem restrição desses filtros.
- Selecionar um ou mais itens em cada grupo, aplicar e validar que o resultado respeita somente as seleções feitas; depois clicar em `Limpar` e confirmar retorno ao estado desmarcado.

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [ ] Altera integração com backend/API
- [ ] Requer configuração adicional
- [ ] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend