### PR TITLE
feat: adiciona campo PIX do motoboy na tela de usuários e no PDF de fechamento

### DIFF
--- a/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-fechamento-pdf.js
@@ -146,6 +146,10 @@
     doc.setFontSize(9.3);
     doc.text(`Código: ${fechamentoCode} | Status: ${statusFechamento} | Entregador: ${entNome}`, M, y);
     y += 4.5;
+    if (fech?.chave_pix) {
+      doc.text(`Chave PIX: ${fech.chave_pix}`, M, y);
+      y += 4.5;
+    }
     doc.text(`Período: ${fmtData(fech.periodo_inicio)} a ${fmtData(fech.periodo_fim)} | Geração: ${new Date().toLocaleString("pt-BR")}`, M, y);
     y += 6;
 

--- a/Master/src/assets/js/pages/tracking-usuarios.js
+++ b/Master/src/assets/js/pages/tracking-usuarios.js
@@ -518,6 +518,8 @@ function openCreate() {
     document.getElementById("documento").value = "";
     const cnpjEl = document.getElementById("cnpj");
     if (cnpjEl) cnpjEl.value = "";
+    const chavePixEl = document.getElementById("chavePix");
+    if (chavePixEl) chavePixEl.value = "";
     document.getElementById("cep").value = "";
     document.getElementById("rua").value = "";
     document.getElementById("numero").value = "";
@@ -539,7 +541,7 @@ function openCreate() {
 }
 
 function clearMotoboyValidation() {
-    ["documento", "cnpj", "cep", "rua", "numero", "bairro", "cidade", "username", "email", "password", "passwordConfirm"].forEach(id => {
+    ["documento", "cnpj", "chavePix", "cep", "rua", "numero", "bairro", "cidade", "username", "email", "password", "passwordConfirm"].forEach(id => {
         const el = document.getElementById(id);
         if (el) el.classList.remove("is-invalid");
     });
@@ -574,6 +576,8 @@ async function openEdit(id) {
     document.getElementById("documento").value = m.documento || "";
     const cnpjEl = document.getElementById("cnpj");
     if (cnpjEl) cnpjEl.value = m.cnpj || "";
+    const chavePixEl = document.getElementById("chavePix");
+    if (chavePixEl) chavePixEl.value = m.chave_pix || "";
     document.getElementById("cep").value = m.cep || "";
     document.getElementById("rua").value = m.rua || "";
     document.getElementById("numero").value = m.numero || "";
@@ -619,6 +623,7 @@ function renderMotoboyDetail(data) {
     };
     assign("d-documento", m.documento);
     assign("d-cnpj", m.cnpj);
+    assign("d-chave-pix", m.chave_pix);
     assign("d-contato", data.contato ? maskCellphone(data.contato) : null);
     assign("d-rua", m.rua);
     assign("d-numero", m.numero);
@@ -750,6 +755,7 @@ async function saveUser(ev) {
     if (role === 4) {
         payload.documento = (document.getElementById("documento").value || "").replace(/\D/g, "");
         payload.cnpj = (document.getElementById("cnpj").value || "").replace(/\D/g, "");
+        payload.chave_pix = (document.getElementById("chavePix").value || "").trim() || null;
         payload.rua = document.getElementById("rua").value.trim();
         payload.numero = document.getElementById("numero").value.trim();
         payload.complemento = document.getElementById("complemento").value.trim() || null;

--- a/Master/src/tracking-usuarios.html
+++ b/Master/src/tracking-usuarios.html
@@ -142,6 +142,10 @@
                                 <div id="d-cnpj">—</div>
                             </div>
                             <div class="col-md-6">
+                                <label class="form-label text-primary fw-medium mb-1">Chave PIX</label>
+                                <div id="d-chave-pix">—</div>
+                            </div>
+                            <div class="col-md-6">
                                 <label class="form-label text-primary fw-medium mb-1">Contato</label>
                                 <div id="d-contato">—</div>
                             </div>
@@ -311,6 +315,12 @@
                             <div class="mb-3">
                                 <label class="form-label">CNPJ</label>
                                 <input type="text" id="cnpj" class="form-control" placeholder="00.000.000/0000-00">
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <div class="mb-3">
+                                <label class="form-label">PIX</label>
+                                <input type="text" id="chavePix" class="form-control" placeholder="Informe a chave PIX (opcional)">
                             </div>
                         </div>
                         <div class="col-6">


### PR DESCRIPTION
## Resumo

Atualiza a tela de usuários e o PDF de fechamento para suportar visualização/edição da chave PIX de motoboy, consumindo o novo campo exposto pelo backend.

## Tipo de alteração

- [x] feature
- [ ] bug
- [ ] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Adicionado campo opcional `PIX` no formulário “Dados do Motoboy” em `tracking-usuarios.html`.
- Atualizado `tracking-usuarios.js` para enviar `chave_pix` no payload, preencher no editar e exibir no card de detalhes do motoboy.
- Atualizado `tracking-entregadores-fechamento-pdf.js` para renderizar “Chave PIX” no cabeçalho do PDF quando houver valor no fechamento.

## Como testar

- Abrir tela de usuários, editar/criar motoboy com `chave_pix` e salvar.
- Selecionar motoboy na lista e validar exibição da chave PIX no bloco “Dados do Motoboy”.
- Gerar PDF de fechamento de motoboy e confirmar presença da linha “Chave PIX” quando preenchida (e ausência quando não preenchida).

## Impacto

- [ ] Sem impacto em produção
- [ ] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend