### PR TITLE
feat: cancelamento e reatribuição de Entregue em Registros e Leitura

### DIFF
--- a/Master/src/assets/js/pages/tracking-leitura.init.js
+++ b/Master/src/assets/js/pages/tracking-leitura.init.js
@@ -1007,6 +1007,8 @@ async function registrar() {
       const idSaida = res.data?.id_saida;
       const entregadorAtual = res.data?.entregador_atual || "Desconhecido";
       const usuarioRegistro = res.data?.username || "Desconhecido";
+      const statusAtualRaw = String(res.data?.status_atual || "").toLowerCase();
+      const pedidoEntregue = statusAtualRaw.indexOf("entregue") !== -1;
       const overlay = document.getElementById("scanFS");
       const wasActiveOverlay = overlay?.classList.contains("show");
       if (wasActiveOverlay) {
@@ -1014,8 +1016,15 @@ async function registrar() {
       }
       const confirm = await Swal.fire({
         icon: "warning",
-        title: "Código já saiu para entrega",
-        html: `
+        title: pedidoEntregue ? "Pedido já entregue" : "Código já saiu para entrega",
+        html: pedidoEntregue
+          ? `
+          <p>O pacote <strong>${codigoFinal}</strong> já está <strong>Entregue</strong>.</p>
+          <p>Entregador atual: <strong>${entregadorAtual}</strong></p>
+          <hr>
+          <p>Deseja reatribuir para <strong>${entregador}</strong> e colocar <strong>Em rota</strong>?</p>
+        `
+          : `
           <p>O pacote <strong>${codigoFinal}</strong> já foi registrado como <strong>Saiu para entrega.</strong></p>
           <p>Registrado por: <strong>${usuarioRegistro}</strong></p>
           <p>Entregador atual: <strong>${entregadorAtual}</strong></p>
@@ -1023,7 +1032,7 @@ async function registrar() {
           <p>Deseja alterar para: <strong>${entregador}</strong>?</p>
         `,
         showCancelButton: true,
-        confirmButtonText: "Sim, alterar entregador",
+        confirmButtonText: pedidoEntregue ? "Sim, reatribuir" : "Sim, alterar entregador",
         cancelButtonText: "Não",
         allowOutsideClick: false,
         backdrop: true
@@ -1032,8 +1041,11 @@ async function registrar() {
         if (wasActiveOverlay) { try { window.leituraStartScanner?.(); } catch (_) { overlay.style.display = "block"; } }
         return { ok:false, tipo:"ja_saiu", backend_processing_ms };
       }
+      const patchBody = pedidoEntregue
+        ? { motoboy_id: motoboyId, entregador }
+        : { status: "Saiu para entrega", motoboy_id: motoboyId, entregador };
       const patchResp = window.TrackAPI?.updateSaida
-        ? await TrackAPI.updateSaida(idSaida, { status: "Saiu para entrega", motoboy_id: motoboyId, entregador })
+        ? await TrackAPI.updateSaida(idSaida, patchBody)
         : { ok: false, error: "TrackAPI.updateSaida não disponível" };
       if (!patchResp.ok) {
         const patchCode = patchResp?.data?.code || patchResp?.data?.detail?.code;
@@ -1050,18 +1062,21 @@ async function registrar() {
         if (wasActiveOverlay) { try { window.leituraStartScanner?.(); } catch (_) { overlay.style.display = "block"; } }
         return { ok:false, tipo:"erro_patch_troca_entregador", detalhe:msg, backend_processing_ms };
       }
+      const statusLinha = pedidoEntregue ? "Em rota" : "Saiu para entrega";
       appendOrUpdateRow({
         tsFmt: new Date().toLocaleString("pt-BR"),
         entregador,
         codigo: codigoFinal,
         servico,
-        status: "Saiu para entrega",
+        status: statusLinha,
         id_saida: idSaida,
         duplicado: false
       });
       codigosLidosSessao.add(codigoFinal);
       updateSummary();
-      showMsgIcon("info", `Entregador alterado ✓ ${codigoFinal}`);
+      showMsgIcon("info", pedidoEntregue
+        ? `Reatribuído — Em rota ✓ ${codigoFinal}`
+        : `Entregador alterado ✓ ${codigoFinal}`);
       Sound.play("ok");
       if (inpCod) { inpCod.value = ""; inpCod.focus(); }
       if (wasActiveOverlay) { try { window.leituraStartScanner?.(); } catch (_) { overlay.style.display = "block"; } }

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1319,6 +1319,13 @@ function setupPagerEvents() {
     }
     if (eBase) eBase.value = row.base || "";
 
+    var editMotoboyHint = document.getElementById("edit-motoboy-hint");
+    if (editMotoboyHint) {
+      editMotoboyHint.textContent = uiStatus === "Entregue"
+        ? "Ao alterar o motoboy, o pedido será reatribuído e colocado Em rota no novo motoboy."
+        : "Alterar o motoboy também mudará o status para \"Saiu para entrega\".";
+    }
+
     eSta?.dispatchEvent(new Event("change"));
     editInitialState = {
       motoboy: eMotoboy?.value || "",
@@ -1346,6 +1353,20 @@ function setupPagerEvents() {
     btnSave.disabled = !isEditChanged();
   }
 
+  function validateBulkHomogeneity(ids){
+    var registros = ids.map(function(id){
+      return state.rows.find(function(r){ return String(getRowId(r)) === String(id); });
+    }).filter(Boolean);
+    if (!registros.length) return false;
+    var statuses = Array.from(new Set(registros.map(function(r){ return normalizeStatusForBulk(r.status); })));
+    var executors = Array.from(new Set(registros.map(function(r){ return getExecutorKeyForBulk(r); })));
+    if (statuses.length > 1 || executors.length > 1){
+      notify("Para edição em lote, selecione pedidos com o mesmo status e o mesmo motoboy.", "warning");
+      return false;
+    }
+    return true;
+  }
+
   if (btnEdit){
     btnEdit.addEventListener("click", () => {
       var ids = getSelectedIds();
@@ -1354,6 +1375,7 @@ function setupPagerEvents() {
       if (ids.length === 1)
         return openEditModal(ids[0]);
 
+      if (!validateBulkHomogeneity(ids)) return;
       return openBulkModal(ids);
     });
   }
@@ -1379,14 +1401,19 @@ function setupPagerEvents() {
         );
       }
 
+      var motoboyChanged = (eMotoboy?.value || "") !== (editInitialState?.motoboy || "");
+      var statusChanged = (eSta?.value || "") !== (editInitialState?.status || "");
+      var cohortEntregue = (editInitialState?.status || "") === "Entregue";
+
       var payload = {
         codigo:     eCod.value,
         servico:    normalizeServicoForEdit(eSrv?.value, eCod?.value),
-        status:     mapStatusToApi(eSta.value)
       };
-      // Correto é pelo id_motoboy (tela de users); quando tem motoboy não enviar entregador (nome) para evitar resolução por nome
-      if (eMotoboy?.value) {
-        payload.motoboy_id = Number(eMotoboy.value);
+      if (cohortEntregue && motoboyChanged && !statusChanged) {
+        if (eMotoboy?.value) payload.motoboy_id = Number(eMotoboy.value);
+      } else {
+        payload.status = mapStatusToApi(eSta.value);
+        if (eMotoboy?.value) payload.motoboy_id = Number(eMotoboy.value);
       }
 
       if ((eSta.value === "Não Coletado" || eSta.value === "Coletado") && eBase?.value)
@@ -1401,7 +1428,15 @@ function setupPagerEvents() {
       if ((eBase?.value || "") !== editInitialState.base) camposAlterados.push("Base");
 
       var confirmMsg = "Campos alterados: " + (camposAlterados.length ? camposAlterados.join(", ") : "nenhum");
-      confirmDlg(confirmMsg, "Confirmar alterações")
+      var confirmTitle = "Confirmar alterações";
+      if (cohortEntregue && eSta?.value === "Cancelado" && statusChanged) {
+        confirmTitle = "Cancelar pedido entregue";
+        confirmMsg = "Este pedido já foi entregue. Deseja cancelar?\n\n" + confirmMsg;
+      } else if (cohortEntregue && motoboyChanged && !statusChanged) {
+        confirmTitle = "Reatribuir pedido entregue";
+        confirmMsg = "O pedido será reatribuído e colocado Em rota no novo motoboy.\n\n" + confirmMsg;
+      }
+      confirmDlg(confirmMsg, confirmTitle)
         .then(function(conf){
           if (!conf?.isConfirmed) return;
           if (btnSave) {
@@ -1466,6 +1501,7 @@ function setupPagerEvents() {
   var bulkBase     = document.getElementById("bulk-base");
   var bulkApplyBtn = document.getElementById("bulk-apply");
   var bulkCurrentIds = [];
+  var bulkCurrentCohortStatus = "";
 
   function normalizeStatusForBulk(rawStatus){
     var s = String(rawStatus || "").toLowerCase().trim();
@@ -1531,6 +1567,7 @@ function setupPagerEvents() {
     ).filter(Boolean);
 
     bulkCurrentIds = ids.slice();
+    bulkCurrentCohortStatus = normalizeStatusForBulk(registros[0]?.status || "");
     if (bulkTitle) bulkTitle.textContent = "Editar " + ids.length + " registros em lote";
     if (bulkSummaryCount) bulkSummaryCount.textContent = String(ids.length);
     if (bulkSummaryServico) bulkSummaryServico.textContent = uniqueValueOrDifferent(registros.map(function(r){ return r?.servico; }), "Não definido");
@@ -1556,6 +1593,12 @@ function setupPagerEvents() {
       bulkBaseGrp?.classList.add("d-none");
       if (bulkBase) bulkBase.value = "";
       if (bulkMotoboy) bulkMotoboy.value = "";
+      var bulkMotoboyHint = document.getElementById("bulk-motoboy-hint");
+      if (bulkMotoboyHint) {
+        bulkMotoboyHint.textContent = bulkCurrentCohortStatus === "entregue"
+          ? "Ao alterar o motoboy, os pedidos entregues serão reatribuídos e colocados Em rota no novo motoboy."
+          : "Alterar o motoboy também mudará o status dos pedidos selecionados para \"Saiu para entrega\".";
+      }
       updateBulkApplyState();
       bulkModal?.show();
     }
@@ -1595,6 +1638,9 @@ function setupPagerEvents() {
       var body = {};
       if (bulkMotoboy?.value) body.motoboy_id = Number(bulkMotoboy.value);
       if (bulkStatus?.value) body.status = mapStatusToApi(bulkStatus.value);
+      if (bulkCurrentCohortStatus === "entregue" && bulkMotoboy?.value && !bulkStatus?.value) {
+        delete body.status;
+      }
       if (bulkServico?.value) body.servico = normalizeServicoForEdit(bulkServico.value, "");
       if ((bulkStatus?.value === "Não Coletado" || bulkStatus?.value === "Coletado") && bulkBase?.value)
         body.base = bulkBase.value;
@@ -1605,7 +1651,18 @@ function setupPagerEvents() {
       if (bulkServico?.value) campos.push("Serviço");
       if (body.base) campos.push("Base");
 
-      confirmDlg("Aplicar alterações em " + ids.length + " registros?\nCampos: " + campos.join(", "), "Confirmar alterações em lote")
+      var bulkConfirmTitle = "Confirmar alterações em lote";
+      var bulkConfirmMsg = "Aplicar alterações em " + ids.length + " registros?\nCampos: " + campos.join(", ");
+      if (bulkCurrentCohortStatus === "entregue" && bulkStatus?.value === "Cancelado") {
+        bulkConfirmTitle = "Cancelar pedidos entregues";
+        bulkConfirmMsg = "Cancelar " + ids.length + " pedidos já entregues?\n\n" + bulkConfirmMsg;
+      } else if (bulkCurrentCohortStatus === "entregue" && bulkMotoboy?.value && !bulkStatus?.value) {
+        var motoboyLabel = bulkMotoboy?.options?.[bulkMotoboy.selectedIndex]?.text || "novo motoboy";
+        bulkConfirmTitle = "Reatribuir pedidos entregues";
+        bulkConfirmMsg = "Reatribuir " + ids.length + " pedidos entregues a " + motoboyLabel + " (Em rota)?\n\n" + bulkConfirmMsg;
+      }
+
+      confirmDlg(bulkConfirmMsg, bulkConfirmTitle)
         .then(function(conf){
           if (!conf?.isConfirmed) return;
           if (bulkApplyBtn) {

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -463,7 +463,7 @@
         <select id="edit-motoboy" class="form-control">
           <option value="">Não alterar</option>
         </select>
-        <div class="alert alert-info py-2 px-3 small mt-2 mb-0">
+        <div id="edit-motoboy-hint" class="alert alert-info py-2 px-3 small mt-2 mb-0">
           Alterar o motoboy também mudará o status para "Saiu para entrega".
         </div>
       </div>
@@ -666,7 +666,7 @@
           </select>
         </div>
 
-        <div class="alert alert-info py-2 px-3 small mb-0">
+        <div id="bulk-motoboy-hint" class="alert alert-info py-2 px-3 small mb-0">
           Alterar o motoboy também mudará o status dos pedidos selecionados para "Saiu para entrega".
         </div>
       </div>


### PR DESCRIPTION
## Resumo

Ajusta a web (Leitura e Registros) e o scan do app motoboy para cancelar e reatribuir pedidos Entregues, alinhado ao novo comportamento do backend (reatribuição → Em rota com evento de reatribuição).

## Tipo de alteração

- [x] feature
- [ ] bug
- [ ] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- **Leitura:** modal e PATCH diferenciados para pedido Entregue (reatribuir → Em rota, sem forçar “Saiu para entrega”)
- **Registros:** edição em lote exige mesmo status e mesmo motoboy; lote Entregue→Cancelado ou reatribuir a novo motoboy
- Confirmações e avisos nos modais singular e em lote (cancelar entregue vs reatribuir)
- Payload de lote: reatribuição de Entregue envia só `motoboy_id` (backend define Em rota)
- **App motoboy (`ScanScreen`):** modal e feedback ao reassumir pedido Entregue de outro motoboy (“Reatribuído — Em rota”)

## Como testar

**Web — Registros**
1. Editar 1 pedido Entregue → Cancelado (confirmação extra)
2. Editar 1 pedido Entregue → trocar motoboy (sem enviar status entregue; pedido fica Em rota)
3. Selecionar N Entregues do mesmo motoboy → lote Cancelado (todos ok)
4. Selecionar N Entregues do mesmo motoboy → lote reatribuir a motoboy B
5. Seleção mista (status ou motoboy diferente) → bloqueio com mensagem

**Web — Leitura**
1. Scan de pedido Entregue de outro motoboy → modal de reatribuição → confirmar → Em rota

**Mobile motoboy**
1. Scan de código Entregue de outro motoboy → modal “Pedido já entregue” → assumir → feedback e pedido na lista Em rota

**Dependência:** requer backend com `PATCH`/`ler`/`scan`/`assumir` atualizados (`track_saidas`).

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [ ] Testei localmente
- [ ] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend