### PR TITLE
perf: listagem de Registros sem aguardar combos

### DIFF
--- a/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
@@ -19,7 +19,21 @@
 
   // ============================================================
   // LISTAR SAÍDAS (limit + offset, compatível com backend novo)
+  // Cache em memória da aba: TTL curto, chave por filtros+página.
   // ============================================================
+  var LISTAR_CACHE_TTL_MS = 45000;
+  var listarCache = new Map();
+  var listarInflight = new Map();
+
+  function listarCacheKey(q) {
+    return q.toString();
+  }
+
+  window.TrackAPI.invalidateListSaidasCache = function () {
+    listarCache.clear();
+    listarInflight.clear();
+  };
+
   window.TrackAPI.listSaidas = async function (params) {
     const limit  = Number(params?.limit  || params?.pageSize || 200);
     const offset = Number(params?.offset || 0);
@@ -53,59 +67,80 @@
     q.set("limit",  String(limit));
     q.set("offset", String(offset));
 
-    try {
-      const res = await req("/saidas/listar?" + q);
-      const ok  = res.ok;
+    const cacheKey = listarCacheKey(q);
+    const bypassCache = !!(params?.codigo || params?.localizar || params?.forceRefresh);
 
-      // total vindo do backend (header)
-      let total = null;
-      const hTotal = res.headers.get("X-Total-Count") || res.headers.get("x-total-count");
-      if (hTotal != null) total = Number(hTotal);
-
-      let data = null;
-      try { data = await res.json(); } catch {}
-
-      let rows = [];
-      if (Array.isArray(data)) rows = data;
-      else if (Array.isArray(data?.items)) { rows = data.items; if (typeof data.total === 'number') total = data.total; }
-      else if (Array.isArray(data?.rows))  { rows = data.rows;  if (typeof data.total === 'number') total = data.total; }
-      else if (Array.isArray(data?.data))  { rows = data.data;  if (typeof data.total === 'number') total = data.total; }
-
-      // fallback caso backend não envie total
-      if (total == null) total = offset + rows.length;
-
-      const hasMore = rows.length === limit;
-
-      // Extrair somas/aggregados com tolerância a diferentes nomes de campo
-      const sumCandidates = (d, keys) => {
-        for (const k of keys) {
-          if (d && typeof d[k] !== 'undefined') return d[k];
-        }
-        return undefined;
-      };
-
-      const sumShopee = sumCandidates(data, ['sumShopee', 'sum_shopee', 'shopee']) ?? data?.sums?.shopee ?? data?.meta?.sumShopee;
-      const sumMercado = sumCandidates(data, ['sumMercado', 'sum_mercado', 'mercado']) ?? data?.sums?.mercado ?? data?.meta?.sumMercado;
-      const sumAvulso = sumCandidates(data, ['sumAvulso', 'sum_avulso', 'avulso']) ?? data?.sums?.avulso ?? data?.meta?.sumAvulso;
-
-      return {
-        ok,
-        status: res.status,
-        rows,
-        total,
-        limit,
-        offset,
-        hasMore,
-        // apenas repassa valores se backend enviar; se undefined, o front pode computar ou exibir fallback
-        sumShopee: typeof sumShopee === 'number' ? sumShopee : undefined,
-        sumMercado: typeof sumMercado === 'number' ? sumMercado : undefined,
-        sumAvulso: typeof sumAvulso === 'number' ? sumAvulso : undefined
-      };
-
-
-    } catch (err) {
-      return { ok: false, status: 0, error: String(err?.message || err) };
+    if (!bypassCache) {
+      const hit = listarCache.get(cacheKey);
+      if (hit && (Date.now() - hit.ts) < LISTAR_CACHE_TTL_MS) {
+        return Object.assign({}, hit.data, { fromCache: true });
+      }
+      if (listarInflight.has(cacheKey)) {
+        return listarInflight.get(cacheKey);
+      }
     }
+
+    const fetchPromise = (async function () {
+      try {
+        const res = await req("/saidas/listar?" + q);
+        const ok  = res.ok;
+
+        let total = null;
+        const hTotal = res.headers.get("X-Total-Count") || res.headers.get("x-total-count");
+        if (hTotal != null) total = Number(hTotal);
+
+        let data = null;
+        try { data = await res.json(); } catch {}
+
+        let rows = [];
+        if (Array.isArray(data)) rows = data;
+        else if (Array.isArray(data?.items)) { rows = data.items; if (typeof data.total === 'number') total = data.total; }
+        else if (Array.isArray(data?.rows))  { rows = data.rows;  if (typeof data.total === 'number') total = data.total; }
+        else if (Array.isArray(data?.data))  { rows = data.data;  if (typeof data.total === 'number') total = data.total; }
+
+        if (total == null) total = offset + rows.length;
+
+        const hasMore = rows.length === limit;
+
+        const sumCandidates = (d, keys) => {
+          for (const k of keys) {
+            if (d && typeof d[k] !== 'undefined') return d[k];
+          }
+          return undefined;
+        };
+
+        const sumShopee = sumCandidates(data, ['sumShopee', 'sum_shopee', 'shopee']) ?? data?.sums?.shopee ?? data?.meta?.sumShopee;
+        const sumMercado = sumCandidates(data, ['sumMercado', 'sum_mercado', 'mercado']) ?? data?.sums?.mercado ?? data?.meta?.sumMercado;
+        const sumAvulso = sumCandidates(data, ['sumAvulso', 'sum_avulso', 'avulso']) ?? data?.sums?.avulso ?? data?.meta?.sumAvulso;
+
+        const result = {
+          ok,
+          status: res.status,
+          rows,
+          total,
+          limit,
+          offset,
+          hasMore,
+          sumShopee: typeof sumShopee === 'number' ? sumShopee : undefined,
+          sumMercado: typeof sumMercado === 'number' ? sumMercado : undefined,
+          sumAvulso: typeof sumAvulso === 'number' ? sumAvulso : undefined
+        };
+
+        if (ok && !bypassCache) {
+          listarCache.set(cacheKey, { ts: Date.now(), data: result });
+        }
+        return result;
+      } catch (err) {
+        return { ok: false, status: 0, error: String(err?.message || err) };
+      } finally {
+        listarInflight.delete(cacheKey);
+      }
+    })();
+
+    if (!bypassCache) {
+      listarInflight.set(cacheKey, fetchPromise);
+    }
+    return fetchPromise;
   };
 
   // Timeout para POST /saidas/ler: não adiciona delay em respostas normais; só aborta se travar (rede/servidor).

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -41,6 +41,18 @@
     });
   }
 
+  function formatPersonName(value) {
+    if (!value || !String(value).trim()) return "—";
+    return String(value).trim().split(/\s+/).map(function (w) {
+      return w.charAt(0).toUpperCase() + w.slice(1).toLowerCase();
+    }).join(" ");
+  }
+
+  function formatPersonNameOrDash(value) {
+    if (!value || !String(value).trim()) return "-";
+    return formatPersonName(value);
+  }
+
 // ======================================================
 // Normalização de código PARA FILTRO (sem classificar)
 // ======================================================
@@ -615,7 +627,7 @@ function augmentEntregadoresFromRows(rows){
             <td><span class="${servicoBadgeClass}">${r.servico || "-"}</span></td>
             <td><span class="${statusBadgeClass}">${r.status || "-"}</span></td>
             <td>${renderActionBadge(r.acao)}</td>
-            <td>${r.entregador || "-"}</td>
+            <td>${formatPersonNameOrDash(r.entregador)}</td>
             <td>${r.tsAcaoFmt || ""}</td>
             <td>${r.tsEntradaFmt || ""}</td>
             <td>${r.executado_por || "—"}</td>
@@ -985,9 +997,25 @@ function setupPagerEvents() {
       var d = saida.detail || {};
       var statusClass = getStatusClass(saida.status);
       var statusText = formatStatusForDisplay(saida.status);
-      var entregador = saida.entregador || "—";
+      var statusLower = (saida.status || "").toLowerCase();
+      var isAusente = statusLower === "ausente";
+      var entregador = formatPersonName(saida.entregador);
       var entregueEv = historico.filter(function(h) { return (h.evento || "").toLowerCase() === "entregue" || (h.status_novo || "").toLowerCase() === "entregue"; }).pop();
-      var dataEntrega = entregueEv && entregueEv.timestamp ? fmtDt(entregueEv.timestamp) : (saida.data_hora_entrega ? fmtDt(saida.data_hora_entrega) : "—");
+      var ausenteEv = historico.filter(function(h) {
+        var ev = (h.evento || "").toLowerCase();
+        return ev === "ausente" || ev === "ausente_lote";
+      }).pop();
+      var dataLabel = isAusente ? "Data da ocorrência" : "Data Entrega";
+      var dataEntrega = isAusente
+        ? (ausenteEv && ausenteEv.timestamp ? fmtDt(ausenteEv.timestamp) : (saida.data_hora_entrega ? fmtDt(saida.data_hora_entrega) : "—"))
+        : (entregueEv && entregueEv.timestamp ? fmtDt(entregueEv.timestamp) : (saida.data_hora_entrega ? fmtDt(saida.data_hora_entrega) : "—"));
+      var motivoAusencia = (d.motivo_ocorrencia && d.motivo_ocorrencia.trim()) ? d.motivo_ocorrencia.trim() : "";
+      var obsAusencia = (d.observacao_ocorrencia && d.observacao_ocorrencia.trim()) ? d.observacao_ocorrencia.trim() : "";
+      var ocorrenciaHtml = isAusente
+        ? '<h6 class="mt-3 mb-2">Ocorrência</h6>' +
+          '<p><strong>Motivo:</strong> ' + (motivoAusencia || "—") + '</p>' +
+          (obsAusencia ? '<p><strong>Observação:</strong> ' + obsAusencia + '</p>' : '')
+        : "";
       var tipoRecebedor = (d.tipo_recebedor && d.tipo_recebedor.trim()) ? d.tipo_recebedor : "—";
       var recebedor = (d.nome_recebedor && d.nome_recebedor.trim()) ? d.nome_recebedor : "—";
       var endParts = [d.dest_rua, d.dest_numero, d.dest_complemento, d.dest_bairro, d.dest_cidade, d.dest_estado, d.dest_cep].filter(Boolean);
@@ -1039,11 +1067,12 @@ function setupPagerEvents() {
             '<div class="pedido-card">' +
               '<h5>Informações da Entrega</h5>' +
               '<p><strong>Entregador:</strong> ' + entregador + '</p>' +
-              '<p><strong>Data Entrega:</strong> ' + dataEntrega + '</p>' +
+              '<p><strong>' + dataLabel + ':</strong> ' + dataEntrega + '</p>' +
               '<p><strong>Tipo do recebedor:</strong> ' + tipoRecebedor + '</p>' +
               '<p><strong>Recebedor:</strong> ' + recebedor + '</p>' +
               '<p><strong>Destino:</strong> ' + enderecoCompleto + '</p>' +
               (destContato ? '<p><strong>Contato destino:</strong> ' + destContato + '</p>' : '') +
+              ocorrenciaHtml +
             '</div>' +
             photoCardHtml +
             '<div class="pedido-card historico-card">' +

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -247,8 +247,14 @@ function parseCodigoFromBusca(rawInput){
   };
   var loadingState = {
     active: false,
-    refreshSeq: 0
+    refreshSeq: 0,
+    combosReady: false
   };
+
+  function syncEntregadorDisabled() {
+    if (!f.entregador) return;
+    f.entregador.disabled = !!loadingState.active || !loadingState.combosReady;
+  }
 
   // ================== Carregar lista de entregadores ==================
 function loadCombosBase(){
@@ -747,6 +753,11 @@ function setupPagerEvents() {
   // =====================================================================
   function ensureUserForG() {
     if (window.__USER__ != null) return Promise.resolve();
+    if (typeof window.ensureAuthUser === "function") {
+      return window.ensureAuthUser().then(function(user) {
+        if (user) window.__USER__ = user;
+      });
+    }
     var api = (window.TRACK_API_URL || "").replace(/\/+$/, "");
     if (!api.endsWith("/api")) api += "/api";
     return fetch(api + "/auth/me", { credentials: "include", headers: { Accept: "application/json" } })
@@ -768,7 +779,7 @@ function setupPagerEvents() {
     if (periodBtnReg) periodBtnReg.disabled = !!show;
     if (f.localizar) f.localizar.disabled = !!show;
     if (fltBase) fltBase.disabled = !!show;
-    if (f.entregador) f.entregador.disabled = !!show;
+    syncEntregadorDisabled();
     if (f.somenteG) f.somenteG.disabled = !!show;
     (f.servicoToggles || []).forEach(function(el){ el.disabled = !!show; });
     (f.statusToggles || []).forEach(function(el){ el.disabled = !!show; });
@@ -1879,6 +1890,16 @@ function setupPagerEvents() {
   // =====================================================================
   // INIT
   // =====================================================================
+  // Combos não bloqueiam a primeira listagem (Etapa 5A).
+  syncEntregadorDisabled();
+  limparFiltrosSelecao();
+  if (f.pageSize) f.pageSize.value = String(state.pageSize);
+  refresh(false);
+  updateEditButtonState();
+  if (typeof atualizarContadorFiltros === "function") atualizarContadorFiltros();
+  setupModoSelecao();
+  if (typeof window.applyOwnerLabels === "function") window.applyOwnerLabels();
+
   Promise.all([loadCombosBase(), loadMotoboys()])
     .then(function(results) {
       var nomesEntregadores = results[0] || [];
@@ -1889,14 +1910,9 @@ function setupPagerEvents() {
       augmentEntregadoresFromRows._base = unicos;
       fillEntregadores(unicos);
     })
-    .finally(() => {
-      limparFiltrosSelecao();
-      if (f.pageSize) f.pageSize.value = String(state.pageSize);
-      refresh(false);
-      updateEditButtonState();
-      if (typeof atualizarContadorFiltros === "function") atualizarContadorFiltros();
-      setupModoSelecao();
-      if (typeof window.applyOwnerLabels === "function") window.applyOwnerLabels();
+    .finally(function() {
+      loadingState.combosReady = true;
+      syncEntregadorDisabled();
     });
 
 })();  // fim do IIFE

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -801,6 +801,12 @@ function setupPagerEvents() {
     });
   }
 
+  function bustListCache() {
+    if (window.TrackAPI && typeof TrackAPI.invalidateListSaidasCache === "function") {
+      TrackAPI.invalidateListSaidasCache();
+    }
+  }
+
   // =====================================================================
   // refresh() — busca e atualiza tabela
   // =====================================================================
@@ -1487,6 +1493,7 @@ function setupPagerEvents() {
           return TrackAPI.updateSaida(id, payload)
         .then(r => {
           if (r.status === 200){
+            bustListCache();
             refresh(true);
             modal?.hide();
             notify("Atualizado com sucesso.", "success");
@@ -1721,6 +1728,7 @@ function setupPagerEvents() {
 
         bulkModal?.hide();
         notify(`Lote concluído: ${ok} ok, ${fail} falha(s).`, fail ? "warning" : "success");
+        bustListCache();
         refresh(false);
         updateEditButtonState();
       }).finally(function(){

--- a/Master/src/assets/js/user.js
+++ b/Master/src/assets/js/user.js
@@ -115,94 +115,123 @@
   })();
 
   // ==========================================================
-  // LOAD LOGGED USER (/auth/me)
+  // LOAD LOGGED USER (/auth/me) — promessa compartilhada (Etapa 5B)
   // ==========================================================
-  async function carregarUsuarioLogado() {
-    try {
-      const resp = await fetch(`${API_ORIGIN}/api/auth/me`, {
-        credentials: "include",
-        headers: { Accept: "application/json" },
-      });
+  let authUserPromise = null;
 
-      if (resp.status === 401) {
-        redirectToLogin("session_expired");
-        return;
-      }
+  function applyUsuarioLogado(user) {
+    if (!user) return null;
+    window.__USER__ = user;
 
-      if (resp.status === 403) {
-        redirectToLogin("owner_blocked");
-        return;
-      }
-
-      if (!resp.ok) return;
-
-      const user = await resp.json();
-      window.__USER__ = user;
-
-      // ----------------------------
-      // Troca de senha obrigatória: bloquear acesso às demais páginas até trocar
-      // ----------------------------
-      if (user && user.must_change_password === true && !isOnProfileSettingsPage()) {
-        window.location.replace(
-          window.location.pathname.replace(/[^/]+$/, "profile-settings-tracking.html") +
-            "?force_password_change=1"
-        );
-        return;
-      }
-
-      // ----------------------------
-      // IGNORAR_COLETA, MODO_OPERACAO e TIPO_OWNER (vem do JWT)
-      // ----------------------------
-      window.IGNORAR_COLETA = !!user?.ignorar_coleta;
-      window.MODO_OPERACAO = user?.modo_operacao || "codigo";
-      window.TIPO_OWNER = (user?.tipo_owner || "subbase").toLowerCase();
-      try {
-        localStorage.setItem(
-          "ignorar_coleta",
-          window.IGNORAR_COLETA ? "1" : "0"
-        );
-      } catch (_) {}
-
-      // ----------------------------
-      // UI
-      // ----------------------------
-      const nome =
-        (user.username || "").trim() ||
-        (user.email || "").trim() ||
-        "Usuário";
-
-      document
-        .querySelectorAll(".user-name-text, .sidebar-user-name-text")
-        .forEach((el) => (el.textContent = nome));
-
-      const ddHeader = document.querySelector(
-        ".dropdown-menu .dropdown-header"
+    // Troca de senha obrigatória: bloquear acesso às demais páginas até trocar
+    if (user.must_change_password === true && !isOnProfileSettingsPage()) {
+      window.location.replace(
+        window.location.pathname.replace(/[^/]+$/, "profile-settings-tracking.html") +
+          "?force_password_change=1"
       );
-      if (ddHeader) ddHeader.textContent = `Bem-vindo(a) ${nome}!`;
-
-      if (typeof window.applyOwnerLabels === "function") {
-        window.applyOwnerLabels();
-      }
-    } catch (e) {
-      // Não logar falhas de rede/API indisponível para reduzir ruído no console
-      const isNetworkError =
-        e?.name === "TypeError" &&
-        (e?.message?.includes("fetch") || e?.message?.includes("Failed to fetch") || e?.message?.includes("NetworkError"));
-      if (!isNetworkError) {
-        console.error("[auth] erro ao carregar usuário:", e);
-      }
+      return user;
     }
+
+    window.IGNORAR_COLETA = !!user?.ignorar_coleta;
+    window.MODO_OPERACAO = user?.modo_operacao || "codigo";
+    window.TIPO_OWNER = (user?.tipo_owner || "subbase").toLowerCase();
+    try {
+      localStorage.setItem(
+        "ignorar_coleta",
+        window.IGNORAR_COLETA ? "1" : "0"
+      );
+    } catch (_) {}
+
+    const nome =
+      (user.username || "").trim() ||
+      (user.email || "").trim() ||
+      "Usuário";
+
+    document
+      .querySelectorAll(".user-name-text, .sidebar-user-name-text")
+      .forEach((el) => (el.textContent = nome));
+
+    const ddHeader = document.querySelector(
+      ".dropdown-menu .dropdown-header"
+    );
+    if (ddHeader) ddHeader.textContent = `Bem-vindo(a) ${nome}!`;
+
+    if (typeof window.applyOwnerLabels === "function") {
+      window.applyOwnerLabels();
+    }
+    return user;
   }
+
+  /**
+   * Deduplica /auth/me entre user.js e páginas (ex.: Registros).
+   * force=true ignora cache em memória (ex.: focus da janela).
+   */
+  async function ensureAuthUser(options) {
+    const force = !!(options && options.force);
+    if (!force && window.__USER__) {
+      return window.__USER__;
+    }
+    if (!force && authUserPromise) {
+      return authUserPromise;
+    }
+
+    const pending = (async () => {
+      try {
+        const resp = await fetch(`${API_ORIGIN}/api/auth/me`, {
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        });
+
+        if (resp.status === 401) {
+          redirectToLogin("session_expired");
+          return null;
+        }
+
+        if (resp.status === 403) {
+          redirectToLogin("owner_blocked");
+          return null;
+        }
+
+        if (!resp.ok) return null;
+
+        const user = await resp.json();
+        return applyUsuarioLogado(user);
+      } catch (e) {
+        const isNetworkError =
+          e?.name === "TypeError" &&
+          (e?.message?.includes("fetch") ||
+            e?.message?.includes("Failed to fetch") ||
+            e?.message?.includes("NetworkError"));
+        if (!isNetworkError) {
+          console.error("[auth] erro ao carregar usuário:", e);
+        }
+        return null;
+      } finally {
+        if (authUserPromise === pending) {
+          authUserPromise = null;
+        }
+      }
+    })();
+
+    authUserPromise = pending;
+    return pending;
+  }
+
+  async function carregarUsuarioLogado(force) {
+    return ensureAuthUser({ force: !!force });
+  }
+
+  window.ensureAuthUser = ensureAuthUser;
 
   // ==========================================================
   // BOOT
   // ==========================================================
   document.addEventListener("DOMContentLoaded", () => {
-    if (!isOnLoginPage()) carregarUsuarioLogado();
+    if (!isOnLoginPage()) carregarUsuarioLogado(false);
   });
 
   window.addEventListener("focus", () => {
-    if (!isOnLoginPage()) carregarUsuarioLogado();
+    if (!isOnLoginPage()) carregarUsuarioLogado(true);
   });
 
 })();


### PR DESCRIPTION
## Resumo

Acelera a abertura da tela Registros desacoplando a primeira listagem dos combos e deduplicando `/auth/me`.

## Tipo de alteração

- [ ] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Inicia `refresh(false)` sem esperar `loadCombosBase`/`loadMotoboys`
- Mantém o select de entregador desabilitado até os combos estarem prontos
- Centraliza `/auth/me` em `window.ensureAuthUser` (promessa compartilhada)

## Como testar

- Abrir Registros e conferir no Network que a listagem parte em paralelo aos combos
- Confirmar no máximo uma chamada efetiva de `/auth/me` na abertura
- Validar filtros, coluna G (permissão) e edição após combos carregarem

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [ ] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Dependência

Homologar junto com o PR de backend `feat/registros-listar-performance` em `track_saidas`.

## Rollback

Deploy anterior de `track_saidas_html`.

Made with [Cursor](https://cursor.com)