### PR TITLE
Timeline de comprovantes, cancelar no detalhe e listagem mais rápida

### DIFF
--- a/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
@@ -271,7 +271,15 @@
       });
       let data = null;
       try { data = await res.json(); } catch {}
-      return { ok: res.ok, status: res.status, data, error: data?.error, code: data?.code };
+      const errDetail = data?.detail;
+      const error = res.ok ? null : (
+        (typeof errDetail === "string" ? errDetail : null) ||
+        (errDetail && typeof errDetail === "object" ? errDetail.message : null) ||
+        data?.message ||
+        data?.error ||
+        null
+      );
+      return { ok: res.ok, status: res.status, data, error, code: data?.code };
     } catch (err) {
       return { ok: false, status: 0, error: String(err?.message || err) };
     }

--- a/Master/src/assets/js/pages/tracking-leitura.init.js
+++ b/Master/src/assets/js/pages/tracking-leitura.init.js
@@ -637,6 +637,22 @@ function createRow(row){
       : Promise.reject(new Error("TrackAPI.lancarAvulso não disponível"));
   }
 
+  function parseApiDetailError(res, fallback) {
+    const data = res && typeof res === "object" ? (res.data || res) : null;
+    const detail = (res && res.detail != null) ? res.detail : (data && data.detail);
+    if (typeof detail === "string" && detail.trim()) return detail.trim();
+    if (detail && typeof detail === "object" && typeof detail.message === "string" && detail.message.trim()) {
+      return detail.message.trim();
+    }
+    if (typeof res?.error === "string" && res.error.trim()) return res.error.trim();
+    if (res?.error && typeof res.error === "object") {
+      const nested = res.error.detail ?? res.error.message;
+      if (typeof nested === "string" && nested.trim()) return nested.trim();
+      if (nested && typeof nested === "object" && typeof nested.message === "string") return nested.message;
+    }
+    return fallback || "Erro ao lançar avulso.";
+  }
+
   // Detecta conflito de duplicidade (409) — sem retry automático.
   function isDupConflict(res) {
     const code = res?.code ?? res?.data?.code ?? res?.data?.detail?.code;
@@ -1489,10 +1505,12 @@ btnLancarAvulso?.addEventListener("click", async (e) => {
     title: "Lançar Avulso",
     html: `
       <div class="text-start">
-        <label class="form-label mb-1">Identificação do avulso (opcional)</label>
-        <input id="avulso-identificacao" class="form-control mb-3" placeholder="Ex.: Cliente João" />
-        <label class="form-label mb-1">Quantidade</label>
-        <input id="avulso-quantidade" type="number" min="1" step="1" class="form-control" value="1" />
+        <label class="form-label mb-1" for="avulso-identificacao">Identificação do avulso (opcional)</label>
+        <input id="avulso-identificacao" class="form-control mb-1" maxlength="32" placeholder="Ex.: Cliente João" />
+        <div class="form-text mb-3">Opcional. Até 32 caracteres para identificar o lote na operação.</div>
+        <label class="form-label mb-1" for="avulso-quantidade">Quantidade</label>
+        <input id="avulso-quantidade" type="number" min="1" max="50" step="1" class="form-control mb-1" value="1" />
+        <div class="form-text">Informe entre 1 e 50 pacotes por lançamento.</div>
       </div>
     `,
     showCancelButton: true,
@@ -1502,10 +1520,19 @@ btnLancarAvulso?.addEventListener("click", async (e) => {
     preConfirm: () => {
       const identificacaoEl = document.getElementById("avulso-identificacao");
       const quantidadeEl = document.getElementById("avulso-quantidade");
-      const identificacaoVal = identificacaoEl ? String(identificacaoEl.value || "").trim() : "";
-      const quantidadeVal = quantidadeEl ? parseInt(String(quantidadeEl.value || "").trim(), 10) : 1;
+      const identificacaoVal = identificacaoEl ? String(identificacaoEl.value || "").trim().slice(0, 32) : "";
+      const quantidadeRaw = quantidadeEl ? String(quantidadeEl.value || "").trim() : "1";
+      const quantidadeVal = parseInt(quantidadeRaw, 10);
+      if (identificacaoVal.length > 32) {
+        Swal.showValidationMessage("Identificação deve ter no máximo 32 caracteres.");
+        return null;
+      }
       if (!Number.isFinite(quantidadeVal) || quantidadeVal < 1) {
         Swal.showValidationMessage("Quantidade mínima é 1.");
+        return null;
+      }
+      if (quantidadeVal > 50) {
+        Swal.showValidationMessage("Quantidade máxima é 50.");
         return null;
       }
       return { identificacao: identificacaoVal, quantidade: quantidadeVal };
@@ -1514,8 +1541,13 @@ btnLancarAvulso?.addEventListener("click", async (e) => {
   if (!modal.isConfirmed || !modal.value) return;
   const identificacao = modal.value.identificacao || "";
   const quantidade = modal.value.quantidade;
-  if (!Number.isFinite(quantidade) || quantidade < 1) {
-    showMsgIcon("erro", "Quantidade mínima é 1.");
+  if (identificacao.length > 32) {
+    showMsgIcon("erro", "Identificação deve ter no máximo 32 caracteres.");
+    Sound.play("err");
+    return;
+  }
+  if (!Number.isFinite(quantidade) || quantidade < 1 || quantidade > 50) {
+    showMsgIcon("erro", "Quantidade deve estar entre 1 e 50.");
     Sound.play("err");
     return;
   }
@@ -1526,7 +1558,7 @@ btnLancarAvulso?.addEventListener("click", async (e) => {
     quantidade,
   });
   if (!res?.ok) {
-    showMsgIcon("erro", res?.error || "Erro ao lançar avulso.");
+    showMsgIcon("erro", parseApiDetailError(res, "Erro ao lançar avulso."));
     Sound.play("err");
     return;
   }

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1037,46 +1037,149 @@ function setupPagerEvents() {
     } catch (_) { return "—"; }
   }
 
+  /** Tentativa vigente no momento do evento (1 + liberações anteriores). */
+  function tentativaNoMomento(historico, eventIndex) {
+    var n = 1;
+    for (var i = 0; i < eventIndex; i++) {
+      var ev = String((historico[i] && historico[i].evento) || "").toLowerCase();
+      if (ev.indexOf("nova_tentativa") !== -1 || ev.indexOf("liberacao_ausencias") !== -1) n += 1;
+    }
+    return n;
+  }
+
+  function grupoFotoKey(evento, tentativa) {
+    return String(evento || "legacy").toLowerCase() + ":" + String(tentativa || 1);
+  }
+
+  /**
+   * Monta mapa evento:tentativa -> [{ url, globalIndex }].
+   * fotosTipadas: [{ key, evento, tentativa }]; urlsByKey: { key: url }.
+   */
+  function buildPhotoGroups(fotosTipadas, urlsByKey, fotoKeysOrder) {
+    var groups = {};
+    var list = Array.isArray(fotosTipadas) && fotosTipadas.length
+      ? fotosTipadas
+      : (fotoKeysOrder || []).map(function(key) {
+          return { key: key, evento: "legacy", tentativa: 1 };
+        });
+    list.forEach(function(item, idx) {
+      var key = String((item && item.key) || "").trim();
+      if (!key) return;
+      var url = urlsByKey[key];
+      if (!url) return;
+      var ev = String((item && item.evento) || "legacy").toLowerCase();
+      var tent = Number(item && item.tentativa) || 1;
+      var gkey = grupoFotoKey(ev, tent);
+      if (!groups[gkey]) groups[gkey] = [];
+      groups[gkey].push({ url: url, globalIndex: idx, key: key, evento: ev, tentativa: tent });
+    });
+    return groups;
+  }
+
+  /**
+   * Associa grupos de foto (por tentativa) aos eventos na ordem cronológica.
+   * Evita desalinhamento quando detail.tentativa já não começa em 1.
+   */
+  function mapPhotosToEventIndexes(historico, groups, kind) {
+    var eventIndexes = [];
+    historico.forEach(function(item, i) {
+      if (kind === "ausente" ? isEventoAusencia(item.evento) : isEventoEntrega(item.evento)) {
+        eventIndexes.push(i);
+      }
+    });
+    var prefix = kind + ":";
+    var tentKeys = Object.keys(groups)
+      .filter(function(k) { return k.indexOf(prefix) === 0; })
+      .sort(function(a, b) {
+        return (Number(a.split(":")[1]) || 0) - (Number(b.split(":")[1]) || 0);
+      });
+    var map = {};
+    eventIndexes.forEach(function(evIdx, i) {
+      if (tentKeys[i] && groups[tentKeys[i]]) map[evIdx] = groups[tentKeys[i]];
+    });
+    return map;
+  }
+
+  function buildEventPhotoMaps(historico, groups) {
+    var ausenciaMap = mapPhotosToEventIndexes(historico, groups, "ausente");
+    var entregaMap = mapPhotosToEventIndexes(historico, groups, "entregue");
+    var legacy = groups[grupoFotoKey("legacy", 1)] || [];
+    if (legacy.length) {
+      var lastEntrega = findLastHistoricoIndexByKeys(historico, isEventoEntrega);
+      var lastAusencia = findLastHistoricoIndexByKeys(historico, isEventoAusencia);
+      var target = lastEntrega >= 0 ? lastEntrega : lastAusencia;
+      if (target >= 0) {
+        var existing = ausenciaMap[target] || entregaMap[target] || [];
+        var merged = existing.concat(legacy);
+        if (isEventoEntrega(historico[target].evento)) entregaMap[target] = merged;
+        else ausenciaMap[target] = merged;
+      }
+    }
+    return { ausenciaMap: ausenciaMap, entregaMap: entregaMap };
+  }
+
+  /** Índice global da 1ª foto do último evento com comprovante (para export/share). */
+  function indexExportUltimoEvento(historico, groups) {
+    var maps = buildEventPhotoMaps(historico, groups);
+    for (var i = historico.length - 1; i >= 0; i--) {
+      var fotos = maps.entregaMap[i] || maps.ausenciaMap[i] || [];
+      if (fotos.length) return fotos[0].globalIndex;
+    }
+    return 0;
+  }
+
   function buildTimeline(historico, ctx) {
     ctx = ctx || {};
     var detailNested = ctx.detailNested || {};
-    var photoThumbUrls = Array.isArray(ctx.photoThumbUrls) ? ctx.photoThumbUrls : [];
+    var photoGroups = ctx.photoGroups || {};
     if (!historico || historico.length === 0)
       return "<p class=\"text-muted small mb-0\">Nenhum evento registrado.</p>";
 
-    var lastEntregaIndex = findLastHistoricoIndexByKeys(historico, isEventoEntrega);
     var lastAusenciaIndex = findLastHistoricoIndexByKeys(historico, isEventoAusencia);
     var motivoAusencia = String(detailNested.motivo_ocorrencia || "").trim();
     var obsAusencia = String(detailNested.observacao_ocorrencia || "").trim();
-    var tentativaNum = detailNested.tentativa;
+    var maps = buildEventPhotoMaps(historico, photoGroups);
+    var ausenciaOrdinal = {};
+    var ausenciaCount = 0;
+    historico.forEach(function(hItem, hIdx) {
+      if (isEventoAusencia(hItem.evento)) {
+        ausenciaCount += 1;
+        ausenciaOrdinal[hIdx] = ausenciaCount;
+      }
+    });
 
     return historico.map(function(item, index) {
       var title = labelEventoHistorico(item.evento, item.acao_label);
       var dateLine = fmtDt(item.timestamp);
       if (item.usuario_nome) dateLine += " — por " + escapeHtml(item.usuario_nome);
 
+      var eventPhotos = [];
+      if (isEventoAusencia(item.evento)) eventPhotos = maps.ausenciaMap[index] || [];
+      else if (isEventoEntrega(item.evento)) eventPhotos = maps.entregaMap[index] || [];
+
       var extrasHtml = "";
-      if (isEventoAusencia(item.evento) && index === lastAusenciaIndex) {
+      if (isEventoAusencia(item.evento)) {
+        // Ordem da ausência no histórico (1ª, 2ª…), não o contador interno atual do pedido.
+        var tentEvento = ausenciaOrdinal[index] || tentativaNoMomento(historico, index);
         extrasHtml += "<div class=\"timeline-extras small text-muted mt-1\">";
-        if (motivoAusencia) extrasHtml += "<div><strong>Motivo:</strong> " + escapeHtml(motivoAusencia) + "</div>";
-        if (obsAusencia) extrasHtml += "<div><strong>Observação:</strong> " + escapeHtml(obsAusencia) + "</div>";
-        if (tentativaNum != null && tentativaNum !== "") {
-          extrasHtml += "<div><strong>Nª tentativa:</strong> " + escapeHtml(String(tentativaNum)) + "</div>";
+        extrasHtml += "<div><strong>Nª tentativa:</strong> " + escapeHtml(String(tentEvento)) + "</div>";
+        if (index === lastAusenciaIndex) {
+          if (motivoAusencia) extrasHtml += "<div><strong>Motivo:</strong> " + escapeHtml(motivoAusencia) + "</div>";
+          if (obsAusencia) extrasHtml += "<div><strong>Observação:</strong> " + escapeHtml(obsAusencia) + "</div>";
         }
         extrasHtml += "</div>";
       }
 
-      var showThumb =
-        photoThumbUrls.length > 0 &&
-        ((isEventoEntrega(item.evento) && index === lastEntregaIndex) ||
-          (isEventoAusencia(item.evento) && index === lastAusenciaIndex));
       var thumbHtml = "";
-      if (showThumb) {
+      if (eventPhotos.length) {
         thumbHtml = "<div class=\"timeline-thumbs d-flex flex-wrap gap-2 mt-2\">" +
-          photoThumbUrls.map(function(url, photoIndex) {
-            return "<a href=\"" + escapeHtml(url) + "\" target=\"_blank\" rel=\"noopener\" class=\"timeline-thumb-link\">" +
-              "<img src=\"" + escapeHtml(url) + "\" alt=\"Comprovante " + (photoIndex + 1) + "\" class=\"rounded border\" style=\"width:80px;height:80px;object-fit:cover;\" />" +
-              "</a>";
+          eventPhotos.map(function(photo, photoIndex) {
+            return "<button type=\"button\" class=\"timeline-thumb-btn border-0 p-0 bg-transparent\" data-photo-url=\"" +
+              escapeHtml(photo.url) +
+              "\" title=\"Ampliar comprovante\">" +
+              "<img src=\"" + escapeHtml(photo.url) + "\" alt=\"Comprovante " + (photoIndex + 1) +
+              "\" class=\"rounded border timeline-thumb-img\" />" +
+              "</button>";
           }).join("") +
           "</div>";
       }
@@ -1243,8 +1346,9 @@ function setupPagerEvents() {
       var enderecoCompleto = endParts.length ? endParts.join(", ") : (d.endereco_formatado || "—");
       var destContato = (d.dest_contato && d.dest_contato.trim()) ? d.dest_contato : "";
 
-      var downloadUrls = [];
       var fotoUrls = d.foto_urls && Array.isArray(d.foto_urls) ? d.foto_urls : [];
+      var fotosTipadas = d.fotos && Array.isArray(d.fotos) ? d.fotos : [];
+      var urlsByKey = {};
       if (fotoUrls.length > 0) {
         try {
           var presignRes = await fetch(base + "/upload/presign-get", {
@@ -1255,45 +1359,38 @@ function setupPagerEvents() {
           });
           if (presignRes.ok) {
             var presignData = await presignRes.json();
-            downloadUrls = presignData.download_urls || (presignData.download_url ? [presignData.download_url] : []);
+            var downloadUrls = presignData.download_urls || (presignData.download_url ? [presignData.download_url] : []);
+            fotoUrls.forEach(function(key, i) {
+              if (downloadUrls[i]) urlsByKey[key] = downloadUrls[i];
+            });
           }
         } catch (e) {
-          downloadUrls = [];
+          urlsByKey = {};
         }
       }
 
+      var photoGroups = buildPhotoGroups(fotosTipadas, urlsByKey, fotoUrls);
+      var exportIndex = indexExportUltimoEvento(historico, photoGroups);
+      var hasPhotos = Object.keys(photoGroups).some(function(k) { return photoGroups[k] && photoGroups[k].length; });
+
       var timelineHtml = buildTimeline(historico, {
         detailNested: d,
-        photoThumbUrls: downloadUrls
+        photoGroups: photoGroups
       });
 
       var bloqueioBadgeHtml = bloqueadoAusencias
         ? '<span class="badge bg-danger ms-2 align-middle">Bloqueado por ausências</span>'
         : "";
       var acoesHtml = "";
-      if (podeLiberar || fotoUrls.length > 0) {
+      if (podeLiberar || hasPhotos) {
         acoesHtml = '<div class="pedido-actions d-flex flex-wrap gap-2 mt-3 mb-2">';
         if (podeLiberar) {
           acoesHtml += '<button type="button" class="btn btn-sm btn-warning" id="btn-liberar-nova-tentativa">Liberar nova tentativa</button>';
         }
-        if (fotoUrls.length > 0) {
+        if (hasPhotos) {
           acoesHtml += '<button type="button" class="btn btn-sm btn-outline-primary" id="btn-export-comprovante">Baixar / compartilhar comprovante</button>';
         }
         acoesHtml += "</div>";
-      }
-
-      var photoCardTitle = (saida.status || "").toLowerCase() === "entregue" ? "Comprovante de Entrega" : "Registro (Ausente)";
-      var photoCardHtml = "";
-      if (downloadUrls.length > 0) {
-        photoCardHtml = '<div class="pedido-card">' +
-          '<h5>' + photoCardTitle + '</h5>' +
-          downloadUrls.map(function(url) {
-            return '<div class="mb-2">' +
-              '<img src="' + url + '" class="img-fluid rounded border" style="max-height:480px; object-fit:contain;" alt="Comprovante">' +
-              '<br><a href="' + url + '" target="_blank" rel="noopener">Abrir em nova aba</a>' +
-              '</div>';
-          }).join('') +
-          '</div>';
       }
 
       var pedidoHtml =
@@ -1303,7 +1400,7 @@ function setupPagerEvents() {
             '<div class="pedido-status status-badge ' + statusClass + '">' + escapeHtml(statusText) + '</div>' +
           '</div>' +
           acoesHtml +
-          '<div class="pedido-grid">' +
+          '<div class="pedido-grid pedido-grid-2">' +
             '<div class="pedido-card">' +
               '<h5>Informações da Entrega</h5>' +
               '<p><strong>Entregador:</strong> ' + escapeHtml(entregador) + '</p>' +
@@ -1314,12 +1411,16 @@ function setupPagerEvents() {
               (destContato ? '<p><strong>Contato destino:</strong> ' + escapeHtml(destContato) + '</p>' : '') +
               ocorrenciaHtml +
             '</div>' +
-            photoCardHtml +
             '<div class="pedido-card historico-card">' +
               '<h5>Histórico</h5>' +
+              '<p class="text-muted small mb-2">Miniaturas por evento. Clique para ampliar.</p>' +
               '<div class="timeline">' + timelineHtml + '</div>' +
             '</div>' +
           '</div>' +
+        '</div>' +
+        '<div id="reg-photo-lightbox" class="reg-photo-lightbox d-none" role="dialog" aria-modal="true">' +
+          '<button type="button" class="reg-photo-lightbox-close" aria-label="Fechar">&times;</button>' +
+          '<img id="reg-photo-lightbox-img" alt="Comprovante ampliado" />' +
         '</div>';
 
       if (detailContent) detailContent.innerHTML = pedidoHtml;
@@ -1337,8 +1438,33 @@ function setupPagerEvents() {
       if (btnExport) {
         btnExport.addEventListener("click", function() {
           btnExport.disabled = true;
-          baixarOuCompartilharComprovante(idSaida, 0).finally(function() {
+          baixarOuCompartilharComprovante(idSaida, exportIndex).finally(function() {
             btnExport.disabled = false;
+          });
+        });
+      }
+
+      var lightbox = document.getElementById("reg-photo-lightbox");
+      var lightboxImg = document.getElementById("reg-photo-lightbox-img");
+      function closeLightbox() {
+        if (!lightbox) return;
+        lightbox.classList.add("d-none");
+        if (lightboxImg) lightboxImg.removeAttribute("src");
+      }
+      if (lightbox) {
+        var closeBtn = lightbox.querySelector(".reg-photo-lightbox-close");
+        if (closeBtn) closeBtn.addEventListener("click", closeLightbox);
+        lightbox.addEventListener("click", function(ev) {
+          if (ev.target === lightbox) closeLightbox();
+        });
+      }
+      if (detailContent) {
+        detailContent.querySelectorAll(".timeline-thumb-btn").forEach(function(btn) {
+          btn.addEventListener("click", function() {
+            var url = btn.getAttribute("data-photo-url");
+            if (!url || !lightbox || !lightboxImg) return;
+            lightboxImg.src = url;
+            lightbox.classList.remove("d-none");
           });
         });
       }

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1052,8 +1052,8 @@ function setupPagerEvents() {
   }
 
   /**
-   * Monta mapa evento:tentativa -> [{ url, globalIndex }].
-   * fotosTipadas: [{ key, evento, tentativa }]; urlsByKey: { key: url }.
+   * Monta mapa evento:tentativa -> [{ url, globalIndex, createdAt, ... }].
+   * fotosTipadas: [{ key, evento, tentativa, created_at }]; urlsByKey: { key: url }.
    */
   function buildPhotoGroups(fotosTipadas, urlsByKey, fotoKeysOrder) {
     var groups = {};
@@ -1070,15 +1070,55 @@ function setupPagerEvents() {
       var ev = String((item && item.evento) || "legacy").toLowerCase();
       var tent = Number(item && item.tentativa) || 1;
       var gkey = grupoFotoKey(ev, tent);
+      var globalIndex = Array.isArray(fotoKeysOrder) ? fotoKeysOrder.indexOf(key) : -1;
+      if (globalIndex < 0) globalIndex = idx;
       if (!groups[gkey]) groups[gkey] = [];
-      groups[gkey].push({ url: url, globalIndex: idx, key: key, evento: ev, tentativa: tent });
+      groups[gkey].push({
+        url: url,
+        globalIndex: globalIndex,
+        key: key,
+        evento: ev,
+        tentativa: tent,
+        createdAt: (item && (item.created_at || item.createdAt)) || null
+      });
     });
     return groups;
   }
 
+  function flattenPhotoGroups(groups, kind) {
+    var photos = [];
+    var prefix = kind + ":";
+    Object.keys(groups || {}).forEach(function(k) {
+      if (k.indexOf(prefix) !== 0) return;
+      (groups[k] || []).forEach(function(p) { photos.push(p); });
+    });
+    return photos;
+  }
+
+  function resolveEventIndexForPhoto(historico, eventIndexes, photo) {
+    if (!eventIndexes.length) return -1;
+    var photoTs = photo && photo.createdAt ? Date.parse(photo.createdAt) : NaN;
+    if (!isNaN(photoTs)) {
+      // Foto costuma ser enviada antes do registro da ausência: liga à 1ª ausência com horário >= foto.
+      for (var j = 0; j < eventIndexes.length; j++) {
+        var evIdx = eventIndexes[j];
+        var evTs = Date.parse((historico[evIdx] && historico[evIdx].timestamp) || "");
+        if (!isNaN(evTs) && evTs >= photoTs) return evIdx;
+      }
+      return eventIndexes[eventIndexes.length - 1];
+    }
+    var tent = Number(photo && photo.tentativa) || 1;
+    for (var k = 0; k < eventIndexes.length; k++) {
+      if (tentativaNoMomento(historico, eventIndexes[k]) === tent) return eventIndexes[k];
+    }
+    // Fallback posicional pelo número da tentativa (1-based).
+    var byOrdinal = eventIndexes[tent - 1];
+    return typeof byOrdinal === "number" ? byOrdinal : eventIndexes[eventIndexes.length - 1];
+  }
+
   /**
-   * Associa grupos de foto (por tentativa) aos eventos na ordem cronológica.
-   * Evita desalinhamento quando detail.tentativa já não começa em 1.
+   * Associa cada foto ao evento de ausência/entrega correspondente.
+   * Prioriza created_at (corrige tentativa duplicada) e cai para tentativa do momento.
    */
   function mapPhotosToEventIndexes(historico, groups, kind) {
     var eventIndexes = [];
@@ -1087,15 +1127,13 @@ function setupPagerEvents() {
         eventIndexes.push(i);
       }
     });
-    var prefix = kind + ":";
-    var tentKeys = Object.keys(groups)
-      .filter(function(k) { return k.indexOf(prefix) === 0; })
-      .sort(function(a, b) {
-        return (Number(a.split(":")[1]) || 0) - (Number(b.split(":")[1]) || 0);
-      });
     var map = {};
-    eventIndexes.forEach(function(evIdx, i) {
-      if (tentKeys[i] && groups[tentKeys[i]]) map[evIdx] = groups[tentKeys[i]];
+    if (!eventIndexes.length) return map;
+    flattenPhotoGroups(groups, kind).forEach(function(photo) {
+      var target = resolveEventIndexForPhoto(historico, eventIndexes, photo);
+      if (target < 0) return;
+      if (!map[target]) map[target] = [];
+      map[target].push(photo);
     });
     return map;
   }
@@ -1105,15 +1143,31 @@ function setupPagerEvents() {
     var entregaMap = mapPhotosToEventIndexes(historico, groups, "entregue");
     var legacy = groups[grupoFotoKey("legacy", 1)] || [];
     if (legacy.length) {
-      var lastEntrega = findLastHistoricoIndexByKeys(historico, isEventoEntrega);
-      var lastAusencia = findLastHistoricoIndexByKeys(historico, isEventoAusencia);
-      var target = lastEntrega >= 0 ? lastEntrega : lastAusencia;
-      if (target >= 0) {
-        var existing = ausenciaMap[target] || entregaMap[target] || [];
-        var merged = existing.concat(legacy);
-        if (isEventoEntrega(historico[target].evento)) entregaMap[target] = merged;
-        else ausenciaMap[target] = merged;
-      }
+      legacy.forEach(function(photo) {
+        var lastEntrega = findLastHistoricoIndexByKeys(historico, isEventoEntrega);
+        var lastAusencia = findLastHistoricoIndexByKeys(historico, isEventoAusencia);
+        var absIndexes = [];
+        var entIndexes = [];
+        historico.forEach(function(item, i) {
+          if (isEventoAusencia(item.evento)) absIndexes.push(i);
+          if (isEventoEntrega(item.evento)) entIndexes.push(i);
+        });
+        var target = -1;
+        if (photo.createdAt && (absIndexes.length || entIndexes.length)) {
+          var all = absIndexes.concat(entIndexes).sort(function(a, b) { return a - b; });
+          target = resolveEventIndexForPhoto(historico, all, photo);
+        } else {
+          target = lastEntrega >= 0 ? lastEntrega : lastAusencia;
+        }
+        if (target < 0) return;
+        if (isEventoEntrega(historico[target].evento)) {
+          if (!entregaMap[target]) entregaMap[target] = [];
+          entregaMap[target].push(photo);
+        } else if (isEventoAusencia(historico[target].evento)) {
+          if (!ausenciaMap[target]) ausenciaMap[target] = [];
+          ausenciaMap[target].push(photo);
+        }
+      });
     }
     return { ausenciaMap: ausenciaMap, entregaMap: entregaMap };
   }
@@ -1136,8 +1190,8 @@ function setupPagerEvents() {
       return "<p class=\"text-muted small mb-0\">Nenhum evento registrado.</p>";
 
     var lastAusenciaIndex = findLastHistoricoIndexByKeys(historico, isEventoAusencia);
-    var motivoAusencia = String(detailNested.motivo_ocorrencia || "").trim();
-    var obsAusencia = String(detailNested.observacao_ocorrencia || "").trim();
+    var motivoDetail = String(detailNested.motivo_ocorrencia || "").trim();
+    var obsDetail = String(detailNested.observacao_ocorrencia || "").trim();
     var maps = buildEventPhotoMaps(historico, photoGroups);
     var ausenciaOrdinal = {};
     var ausenciaCount = 0;
@@ -1160,13 +1214,16 @@ function setupPagerEvents() {
       var extrasHtml = "";
       if (isEventoAusencia(item.evento)) {
         // Ordem da ausência no histórico (1ª, 2ª…), não o contador interno atual do pedido.
-        var tentEvento = ausenciaOrdinal[index] || tentativaNoMomento(historico, index);
+        var tentEvento = ausenciaOrdinal[index] || Number(item.tentativa) || tentativaNoMomento(historico, index);
+        var motivoEvento = String(item.motivo_ocorrencia || "").trim();
+        var obsEvento = String(item.observacao_ocorrencia || "").trim();
+        // Retrocompat: eventos antigos sem payload só têm motivo no detalhe atual.
+        if (!motivoEvento && index === lastAusenciaIndex) motivoEvento = motivoDetail;
+        if (!obsEvento && index === lastAusenciaIndex) obsEvento = obsDetail;
         extrasHtml += "<div class=\"timeline-extras small text-muted mt-1\">";
         extrasHtml += "<div><strong>Nª tentativa:</strong> " + escapeHtml(String(tentEvento)) + "</div>";
-        if (index === lastAusenciaIndex) {
-          if (motivoAusencia) extrasHtml += "<div><strong>Motivo:</strong> " + escapeHtml(motivoAusencia) + "</div>";
-          if (obsAusencia) extrasHtml += "<div><strong>Observação:</strong> " + escapeHtml(obsAusencia) + "</div>";
-        }
+        if (motivoEvento) extrasHtml += "<div><strong>Motivo:</strong> " + escapeHtml(motivoEvento) + "</div>";
+        if (obsEvento) extrasHtml += "<div><strong>Observação:</strong> " + escapeHtml(obsEvento) + "</div>";
         extrasHtml += "</div>";
       }
 

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1115,11 +1115,14 @@ function setupPagerEvents() {
       var statusLabel = (res.headers.get("X-Comprovante-Status") || "").trim();
       var dataHora = (res.headers.get("X-Comprovante-Data") || "").trim();
       var recebedor = (res.headers.get("X-Comprovante-Recebedor") || "").trim();
+      var entregador = (res.headers.get("X-Comprovante-Entregador") || "").trim();
+      var labelEntregador = (String(statusLabel || "").toLowerCase() === "entregue") ? "Entregue por" : "Motoboy";
       var captionParts = [
         statusLabel ? ("Comprovante — " + statusLabel) : "Comprovante de entrega",
         codigo ? ("Código: " + codigo) : null,
         dataHora ? ("Data/hora: " + dataHora) : null,
-        recebedor ? ("Recebido por: " + recebedor) : null
+        recebedor ? ("Recebido por: " + recebedor) : null,
+        entregador ? (labelEntregador + ": " + entregador) : null
       ].filter(Boolean);
       var caption = captionParts.join("\n");
       var file = new File([blob], filename, { type: blob.type || "image/jpeg" });

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -559,6 +559,88 @@ function augmentEntregadoresFromRows(rows){
       .replace(/'/g, "&#39;");
   }
 
+  function parseApiDetailMessage(payload, fallback) {
+    var detail = payload && payload.detail != null ? payload.detail : null;
+    if (typeof detail === "string" && detail.trim()) return detail.trim();
+    if (detail && typeof detail === "object" && typeof detail.message === "string") return detail.message.trim();
+    if (typeof payload === "string" && payload.trim()) return payload.trim();
+    return fallback || "Erro na operação.";
+  }
+
+  var EVENTO_HISTORICO_LABELS = {
+    scan: "Pedido adicionado",
+    lido: "Pedido adicionado",
+    leitura: "Pedido adicionado",
+    lancar_avulso: "Pedido adicionado",
+    em_rota: "Saiu para entrega",
+    saiu: "Saiu para entrega",
+    entregue: "Entrega realizada",
+    entregue_lote: "Entrega realizada",
+    ausente: "Destinatário ausente",
+    ausente_lote: "Destinatário ausente",
+    cancelado: "Pedido cancelado",
+    nova_tentativa: "Nova tentativa liberada",
+    liberacao_ausencias: "Nova tentativa liberada pela operação",
+    coleta: "Pacote coletado",
+    criado_coleta: "Pacote coletado",
+    reatribuido: "Entregador reatribuído",
+    reatribuicao: "Entregador reatribuído",
+    assumir: "Entregador reatribuído",
+    assumido: "Entregador reatribuído",
+    reatribuido_em_rota: "Entregador reatribuído em rota",
+    nova_saida_mesmo_entregador: "Nova saída confirmada",
+    desatribuido: "Pacote desatribuído",
+    removido_sem_inicio: "Removido antes de iniciar rota",
+    endereco_atualizado: "Endereço atualizado",
+    rota_criada: "Inserido na rota",
+    rota_recalculada: "Rota recalculada"
+  };
+
+  function normalizeEventoKey(evento) {
+    var raw = String(evento || "").trim().toLowerCase().replace(/\s+/g, "_");
+    if (!raw) return "unknown";
+    if (Object.prototype.hasOwnProperty.call(EVENTO_HISTORICO_LABELS, raw)) return raw;
+    if (raw.indexOf("entregue") !== -1) return "entregue";
+    if (raw.indexOf("ausente") !== -1) return "ausente";
+    if (raw.indexOf("cancel") !== -1) return "cancelado";
+    if (raw.indexOf("endereco") !== -1) return "endereco_atualizado";
+    if (raw.indexOf("recalcul") !== -1) return "rota_recalculada";
+    if (raw.indexOf("rota_criada") !== -1 || raw === "rota_criada") return "rota_criada";
+    if (raw.indexOf("rota") !== -1 || raw === "saiu") return raw === "saiu" ? "saiu" : "em_rota";
+    if (raw.indexOf("scan") !== -1 || raw.indexOf("escane") !== -1) return "scan";
+    if (raw.indexOf("lido") !== -1 || raw.indexOf("leitura") !== -1) return "lido";
+    if (raw.indexOf("coleta") !== -1) return "coleta";
+    if (raw.indexOf("reatrib") !== -1) return "reatribuido";
+    return "unknown";
+  }
+
+  function labelEventoHistorico(evento, acaoLabel) {
+    var key = normalizeEventoKey(evento);
+    var mapped = EVENTO_HISTORICO_LABELS[key];
+    if (mapped) return mapped;
+    var fallback = String(acaoLabel || "").trim();
+    if (fallback) return fallback;
+    return "Movimentação registrada";
+  }
+
+  function isEventoEntrega(evento) {
+    var key = normalizeEventoKey(evento);
+    return key === "entregue" || key === "entregue_lote";
+  }
+
+  function isEventoAusencia(evento) {
+    var key = normalizeEventoKey(evento);
+    return key === "ausente" || key === "ausente_lote";
+  }
+
+  function findLastHistoricoIndexByKeys(historico, matcher) {
+    var last = -1;
+    (historico || []).forEach(function(item, index) {
+      if (matcher(item.evento)) last = index;
+    });
+    return last;
+  }
+
   var ACTION_BADGE_MAP = {
     "Leu pedido": { category: "neutral", className: "action-neutral" },
     "Escaneou pedido": { category: "neutral", className: "action-neutral" },
@@ -955,30 +1037,120 @@ function setupPagerEvents() {
     } catch (_) { return "—"; }
   }
 
-  function buildTimeline(historico) {
-    var eventLabels = {
-      criado: "Criado",
-      lido: "Lido",
-      criado_coleta: "Coleta",
-      em_rota: "Em rota",
-      entregue: "Entregue",
-      ausente: "Ausente",
-      nova_tentativa: "Nova tentativa",
-      scan: "Scan",
-      assumir: "Assumir",
-      reatribuicao: "Reatribuição",
-      nova_saida_mesmo_entregador: "Nova saída confirmada pelo mesmo motoboy"
-    };
+  function buildTimeline(historico, ctx) {
+    ctx = ctx || {};
+    var detailNested = ctx.detailNested || {};
+    var photoThumbUrls = Array.isArray(ctx.photoThumbUrls) ? ctx.photoThumbUrls : [];
     if (!historico || historico.length === 0)
       return "<p class=\"text-muted small mb-0\">Nenhum evento registrado.</p>";
-    return historico.map(function(item) {
-      var title = item.acao_label || eventLabels[item.evento] || item.evento;
-      if (item.status_anterior && item.status_novo) title += " (" + formatStatusForDisplay(item.status_anterior) + " → " + formatStatusForDisplay(item.status_novo) + ")";
+
+    var lastEntregaIndex = findLastHistoricoIndexByKeys(historico, isEventoEntrega);
+    var lastAusenciaIndex = findLastHistoricoIndexByKeys(historico, isEventoAusencia);
+    var motivoAusencia = String(detailNested.motivo_ocorrencia || "").trim();
+    var obsAusencia = String(detailNested.observacao_ocorrencia || "").trim();
+    var tentativaNum = detailNested.tentativa;
+
+    return historico.map(function(item, index) {
+      var title = labelEventoHistorico(item.evento, item.acao_label);
       var dateLine = fmtDt(item.timestamp);
-      if (item.usuario_nome) dateLine += " — por " + item.usuario_nome;
-      else if (item.user_id) dateLine += " — user " + item.user_id;
-      return "<div class=\"timeline-item\"><div class=\"timeline-dot\"></div><div class=\"timeline-content\"><div class=\"timeline-title\">" + title + "</div><div class=\"timeline-date\">" + dateLine + "</div></div></div>";
+      if (item.usuario_nome) dateLine += " — por " + escapeHtml(item.usuario_nome);
+
+      var extrasHtml = "";
+      if (isEventoAusencia(item.evento) && index === lastAusenciaIndex) {
+        extrasHtml += "<div class=\"timeline-extras small text-muted mt-1\">";
+        if (motivoAusencia) extrasHtml += "<div><strong>Motivo:</strong> " + escapeHtml(motivoAusencia) + "</div>";
+        if (obsAusencia) extrasHtml += "<div><strong>Observação:</strong> " + escapeHtml(obsAusencia) + "</div>";
+        if (tentativaNum != null && tentativaNum !== "") {
+          extrasHtml += "<div><strong>Nª tentativa:</strong> " + escapeHtml(String(tentativaNum)) + "</div>";
+        }
+        extrasHtml += "</div>";
+      }
+
+      var showThumb =
+        photoThumbUrls.length > 0 &&
+        ((isEventoEntrega(item.evento) && index === lastEntregaIndex) ||
+          (isEventoAusencia(item.evento) && index === lastAusenciaIndex));
+      var thumbHtml = "";
+      if (showThumb) {
+        thumbHtml = "<div class=\"timeline-thumbs d-flex flex-wrap gap-2 mt-2\">" +
+          photoThumbUrls.map(function(url, photoIndex) {
+            return "<a href=\"" + escapeHtml(url) + "\" target=\"_blank\" rel=\"noopener\" class=\"timeline-thumb-link\">" +
+              "<img src=\"" + escapeHtml(url) + "\" alt=\"Comprovante " + (photoIndex + 1) + "\" class=\"rounded border\" style=\"width:80px;height:80px;object-fit:cover;\" />" +
+              "</a>";
+          }).join("") +
+          "</div>";
+      }
+
+      return "<div class=\"timeline-item\"><div class=\"timeline-dot\"></div><div class=\"timeline-content\">" +
+        "<div class=\"timeline-title\">" + escapeHtml(title) + "</div>" +
+        "<div class=\"timeline-date\">" + dateLine + "</div>" +
+        extrasHtml +
+        thumbHtml +
+        "</div></div>";
     }).join("");
+  }
+
+  async function baixarOuCompartilharComprovante(idSaida, index) {
+    var base = (window.TRACK_API_URL || "").replace(/\/+$/, "");
+    var url = base + "/upload/saida/" + encodeURIComponent(String(idSaida)) + "/comprovante-export";
+    try {
+      var res = await fetch(url, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ index: Number.isFinite(index) ? index : 0 })
+      });
+      if (!res.ok) {
+        var errBody = null;
+        try { errBody = await res.json(); } catch (_) {}
+        notify(parseApiDetailMessage(errBody, "Erro ao exportar comprovante."), "error");
+        return;
+      }
+      var blob = await res.blob();
+      var filename = "comprovante-" + idSaida + ".jpg";
+      var cd = res.headers.get("Content-Disposition") || "";
+      var match = /filename=\"?([^\";]+)\"?/i.exec(cd);
+      if (match && match[1]) filename = match[1];
+      var file = new File([blob], filename, { type: blob.type || "image/jpeg" });
+      if (navigator.share && typeof navigator.canShare === "function" && navigator.canShare({ files: [file] })) {
+        await navigator.share({ files: [file], title: "Comprovante de entrega" });
+        return;
+      }
+      var objectUrl = URL.createObjectURL(blob);
+      var a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(function() { URL.revokeObjectURL(objectUrl); }, 1000);
+    } catch (err) {
+      notify(err && err.message ? err.message : "Erro ao exportar comprovante.", "error");
+    }
+  }
+
+  async function liberarNovaTentativa(idSaida) {
+    var base = (window.TRACK_API_URL || "").replace(/\/+$/, "");
+    var confirm = await confirmDlg("Deseja liberar nova tentativa para este pedido?", "Liberar nova tentativa");
+    if (!confirm || !confirm.isConfirmed) return false;
+    try {
+      var res = await fetch(base + "/saidas/" + encodeURIComponent(String(idSaida)) + "/liberar-nova-tentativa", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Accept": "application/json" }
+      });
+      var body = null;
+      try { body = await res.json(); } catch (_) {}
+      if (!res.ok) {
+        notify(parseApiDetailMessage(body, "Erro ao liberar nova tentativa."), "error");
+        return false;
+      }
+      notify((body && body.message) || "Nova tentativa liberada.", "success");
+      return true;
+    } catch (err) {
+      notify(err && err.message ? err.message : "Erro ao liberar nova tentativa.", "error");
+      return false;
+    }
   }
 
   function closeDetailPanel() {
@@ -1028,6 +1200,8 @@ function setupPagerEvents() {
       var statusText = formatStatusForDisplay(saida.status);
       var statusLower = (saida.status || "").toLowerCase();
       var isAusente = statusLower === "ausente";
+      var bloqueadoAusencias = !!saida.bloqueado_ausencias;
+      var podeLiberar = canEditG() && bloqueadoAusencias;
       var entregador = formatPersonName(saida.entregador);
       var entregueEv = historico.filter(function(h) { return (h.evento || "").toLowerCase() === "entregue" || (h.status_novo || "").toLowerCase() === "entregue"; }).pop();
       var ausenteEv = historico.filter(function(h) {
@@ -1042,16 +1216,14 @@ function setupPagerEvents() {
       var obsAusencia = (d.observacao_ocorrencia && d.observacao_ocorrencia.trim()) ? d.observacao_ocorrencia.trim() : "";
       var ocorrenciaHtml = isAusente
         ? '<h6 class="mt-3 mb-2">Ocorrência</h6>' +
-          '<p><strong>Motivo:</strong> ' + (motivoAusencia || "—") + '</p>' +
-          (obsAusencia ? '<p><strong>Observação:</strong> ' + obsAusencia + '</p>' : '')
+          '<p><strong>Motivo:</strong> ' + escapeHtml(motivoAusencia || "—") + '</p>' +
+          (obsAusencia ? '<p><strong>Observação:</strong> ' + escapeHtml(obsAusencia) + '</p>' : '')
         : "";
       var tipoRecebedor = (d.tipo_recebedor && d.tipo_recebedor.trim()) ? d.tipo_recebedor : "—";
       var recebedor = (d.nome_recebedor && d.nome_recebedor.trim()) ? d.nome_recebedor : "—";
       var endParts = [d.dest_rua, d.dest_numero, d.dest_complemento, d.dest_bairro, d.dest_cidade, d.dest_estado, d.dest_cep].filter(Boolean);
       var enderecoCompleto = endParts.length ? endParts.join(", ") : (d.endereco_formatado || "—");
       var destContato = (d.dest_contato && d.dest_contato.trim()) ? d.dest_contato : "";
-
-      var timelineHtml = buildTimeline(historico);
 
       var downloadUrls = [];
       var fotoUrls = d.foto_urls && Array.isArray(d.foto_urls) ? d.foto_urls : [];
@@ -1072,6 +1244,26 @@ function setupPagerEvents() {
         }
       }
 
+      var timelineHtml = buildTimeline(historico, {
+        detailNested: d,
+        photoThumbUrls: downloadUrls
+      });
+
+      var bloqueioBadgeHtml = bloqueadoAusencias
+        ? '<span class="badge bg-danger ms-2 align-middle">Bloqueado por ausências</span>'
+        : "";
+      var acoesHtml = "";
+      if (podeLiberar || fotoUrls.length > 0) {
+        acoesHtml = '<div class="pedido-actions d-flex flex-wrap gap-2 mt-3 mb-2">';
+        if (podeLiberar) {
+          acoesHtml += '<button type="button" class="btn btn-sm btn-warning" id="btn-liberar-nova-tentativa">Liberar nova tentativa</button>';
+        }
+        if (fotoUrls.length > 0) {
+          acoesHtml += '<button type="button" class="btn btn-sm btn-outline-primary" id="btn-export-comprovante">Baixar / compartilhar comprovante</button>';
+        }
+        acoesHtml += "</div>";
+      }
+
       var photoCardTitle = (saida.status || "").toLowerCase() === "entregue" ? "Comprovante de Entrega" : "Registro (Ausente)";
       var photoCardHtml = "";
       if (downloadUrls.length > 0) {
@@ -1089,18 +1281,19 @@ function setupPagerEvents() {
       var pedidoHtml =
         '<div class="pedido-detail-container">' +
           '<div class="pedido-header">' +
-            '<div class="pedido-codigo">' + (saida.codigo || idSaida) + '</div>' +
-            '<div class="pedido-status status-badge ' + statusClass + '">' + statusText + '</div>' +
+            '<div class="pedido-codigo">' + escapeHtml(saida.codigo || idSaida) + bloqueioBadgeHtml + '</div>' +
+            '<div class="pedido-status status-badge ' + statusClass + '">' + escapeHtml(statusText) + '</div>' +
           '</div>' +
+          acoesHtml +
           '<div class="pedido-grid">' +
             '<div class="pedido-card">' +
               '<h5>Informações da Entrega</h5>' +
-              '<p><strong>Entregador:</strong> ' + entregador + '</p>' +
-              '<p><strong>' + dataLabel + ':</strong> ' + dataEntrega + '</p>' +
-              '<p><strong>Tipo do recebedor:</strong> ' + tipoRecebedor + '</p>' +
-              '<p><strong>Recebedor:</strong> ' + recebedor + '</p>' +
-              '<p><strong>Destino:</strong> ' + enderecoCompleto + '</p>' +
-              (destContato ? '<p><strong>Contato destino:</strong> ' + destContato + '</p>' : '') +
+              '<p><strong>Entregador:</strong> ' + escapeHtml(entregador) + '</p>' +
+              '<p><strong>' + escapeHtml(dataLabel) + ':</strong> ' + escapeHtml(dataEntrega) + '</p>' +
+              '<p><strong>Tipo do recebedor:</strong> ' + escapeHtml(tipoRecebedor) + '</p>' +
+              '<p><strong>Recebedor:</strong> ' + escapeHtml(recebedor) + '</p>' +
+              '<p><strong>Destino:</strong> ' + escapeHtml(enderecoCompleto) + '</p>' +
+              (destContato ? '<p><strong>Contato destino:</strong> ' + escapeHtml(destContato) + '</p>' : '') +
               ocorrenciaHtml +
             '</div>' +
             photoCardHtml +
@@ -1112,6 +1305,25 @@ function setupPagerEvents() {
         '</div>';
 
       if (detailContent) detailContent.innerHTML = pedidoHtml;
+
+      var btnLiberar = document.getElementById("btn-liberar-nova-tentativa");
+      if (btnLiberar) {
+        btnLiberar.addEventListener("click", async function() {
+          btnLiberar.disabled = true;
+          var ok = await liberarNovaTentativa(idSaida);
+          btnLiberar.disabled = false;
+          if (ok) openDetailPanel(idSaida);
+        });
+      }
+      var btnExport = document.getElementById("btn-export-comprovante");
+      if (btnExport) {
+        btnExport.addEventListener("click", function() {
+          btnExport.disabled = true;
+          baixarOuCompartilharComprovante(idSaida, 0).finally(function() {
+            btnExport.disabled = false;
+          });
+        });
+      }
 
       if (detailLoading) detailLoading.classList.add("d-none");
       if (detailBody) detailBody.classList.remove("d-none");

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1111,9 +1111,24 @@ function setupPagerEvents() {
       var cd = res.headers.get("Content-Disposition") || "";
       var match = /filename=\"?([^\";]+)\"?/i.exec(cd);
       if (match && match[1]) filename = match[1];
+      var codigo = (res.headers.get("X-Comprovante-Codigo") || "").trim();
+      var statusLabel = (res.headers.get("X-Comprovante-Status") || "").trim();
+      var dataHora = (res.headers.get("X-Comprovante-Data") || "").trim();
+      var recebedor = (res.headers.get("X-Comprovante-Recebedor") || "").trim();
+      var captionParts = [
+        statusLabel ? ("Comprovante — " + statusLabel) : "Comprovante de entrega",
+        codigo ? ("Código: " + codigo) : null,
+        dataHora ? ("Data/hora: " + dataHora) : null,
+        recebedor ? ("Recebido por: " + recebedor) : null
+      ].filter(Boolean);
+      var caption = captionParts.join("\n");
       var file = new File([blob], filename, { type: blob.type || "image/jpeg" });
       if (navigator.share && typeof navigator.canShare === "function" && navigator.canShare({ files: [file] })) {
-        await navigator.share({ files: [file], title: "Comprovante de entrega" });
+        await navigator.share({
+          files: [file],
+          title: statusLabel ? ("Comprovante — " + statusLabel) : "Comprovante de entrega",
+          text: caption
+        });
         return;
       }
       var objectUrl = URL.createObjectURL(blob);

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1274,6 +1274,33 @@ function setupPagerEvents() {
     }
   }
 
+  async function cancelarPedido(idSaida) {
+    var confirm = await confirmDlg(
+      "Deseja cancelar este pedido? Ele deixará de contar na cobrança.",
+      "Cancelar pedido"
+    );
+    if (!confirm || !confirm.isConfirmed) return false;
+    if (!window.TrackAPI || typeof window.TrackAPI.updateSaida !== "function") {
+      notify("API de atualização não disponível.", "error");
+      return false;
+    }
+    try {
+      var r = await window.TrackAPI.updateSaida(idSaida, { status: "cancelado" });
+      if (r && r.status === 200) {
+        notify("Pedido cancelado.", "success");
+        return true;
+      }
+      var msg = (r && r.data && (r.data.detail || r.data.message)) || (r && r.error) || "";
+      if (typeof msg === "object" && msg !== null && msg.message) msg = msg.message;
+      else if (Array.isArray(msg)) msg = msg.map(function(d){ return d.msg || d.message; }).join("; ");
+      notify(String(msg || "Erro ao cancelar pedido."), "error");
+      return false;
+    } catch (err) {
+      notify(err && err.message ? err.message : "Erro ao cancelar pedido.", "error");
+      return false;
+    }
+  }
+
   function closeDetailPanel() {
     if (detailOverlay) detailOverlay.classList.remove("show");
     if (detailPanel) detailPanel.classList.remove("open");
@@ -1323,6 +1350,8 @@ function setupPagerEvents() {
       var isAusente = statusLower === "ausente";
       var bloqueadoAusencias = !!saida.bloqueado_ausencias;
       var podeLiberar = canEditG() && bloqueadoAusencias;
+      var statusJaCancelado = statusLower === "cancelado";
+      var podeCancelar = canEditG() && !statusJaCancelado;
       var entregador = formatPersonName(saida.entregador);
       var entregueEv = historico.filter(function(h) { return (h.evento || "").toLowerCase() === "entregue" || (h.status_novo || "").toLowerCase() === "entregue"; }).pop();
       var ausenteEv = historico.filter(function(h) {
@@ -1382,10 +1411,13 @@ function setupPagerEvents() {
         ? '<span class="badge bg-danger ms-2 align-middle">Bloqueado por ausências</span>'
         : "";
       var acoesHtml = "";
-      if (podeLiberar || hasPhotos) {
+      if (podeLiberar || podeCancelar || hasPhotos) {
         acoesHtml = '<div class="pedido-actions d-flex flex-wrap gap-2 mt-3 mb-2">';
         if (podeLiberar) {
           acoesHtml += '<button type="button" class="btn btn-sm btn-warning" id="btn-liberar-nova-tentativa">Liberar nova tentativa</button>';
+        }
+        if (podeCancelar) {
+          acoesHtml += '<button type="button" class="btn btn-sm btn-outline-danger" id="btn-cancelar-pedido">Cancelar pedido</button>';
         }
         if (hasPhotos) {
           acoesHtml += '<button type="button" class="btn btn-sm btn-outline-primary" id="btn-export-comprovante">Baixar / compartilhar comprovante</button>';
@@ -1432,6 +1464,19 @@ function setupPagerEvents() {
           var ok = await liberarNovaTentativa(idSaida);
           btnLiberar.disabled = false;
           if (ok) openDetailPanel(idSaida);
+        });
+      }
+      var btnCancelar = document.getElementById("btn-cancelar-pedido");
+      if (btnCancelar) {
+        btnCancelar.addEventListener("click", async function() {
+          btnCancelar.disabled = true;
+          var ok = await cancelarPedido(idSaida);
+          btnCancelar.disabled = false;
+          if (ok) {
+            if (typeof bustListCache === "function") bustListCache();
+            if (typeof refresh === "function") refresh(true);
+            openDetailPanel(idSaida);
+          }
         });
       }
       var btnExport = document.getElementById("btn-export-comprovante");
@@ -1829,7 +1874,10 @@ function setupPagerEvents() {
         if (eMotoboy?.value) payload.motoboy_id = Number(eMotoboy.value);
       } else {
         payload.status = mapStatusToApi(eSta.value);
-        if (eMotoboy?.value) payload.motoboy_id = Number(eMotoboy.value);
+        // Ao cancelar, não enviar motoboy_id (evita reabertura/reatribuição indevida).
+        if (eSta.value !== "Cancelado" && eMotoboy?.value) {
+          payload.motoboy_id = Number(eMotoboy.value);
+        }
       }
 
       if ((eSta.value === "Não Coletado" || eSta.value === "Coletado") && eBase?.value)
@@ -2053,8 +2101,11 @@ function setupPagerEvents() {
       }
 
       var body = {};
-      if (bulkMotoboy?.value) body.motoboy_id = Number(bulkMotoboy.value);
       if (bulkStatus?.value) body.status = mapStatusToApi(bulkStatus.value);
+      // Ao cancelar, não enviar motoboy_id (evita bloqueio de ausências / reabertura).
+      if (bulkMotoboy?.value && bulkStatus?.value !== "Cancelado") {
+        body.motoboy_id = Number(bulkMotoboy.value);
+      }
       if (bulkCurrentCohortStatus === "entregue" && bulkMotoboy?.value && !bulkStatus?.value) {
         delete body.status;
       }

--- a/Master/src/assets/js/pages/tracking-usuarios.js
+++ b/Master/src/assets/js/pages/tracking-usuarios.js
@@ -529,6 +529,7 @@ function openCreate() {
     document.getElementById("estado").value = "";
     document.getElementById("podeLerColeta").checked = false;
     document.getElementById("podeLerSaida").checked = true;
+    document.getElementById("podeDigitarCodigoManual").checked = false;
 
     document.getElementById("groupPassword").classList.remove("d-none");
     document.getElementById("groupPasswordConfirm").classList.remove("d-none");
@@ -587,6 +588,7 @@ async function openEdit(id) {
     document.getElementById("estado").value = m.estado || "";
     document.getElementById("podeLerColeta").checked = !!m.pode_ler_coleta;
     document.getElementById("podeLerSaida").checked = m.pode_ler_saida !== false;
+    document.getElementById("podeDigitarCodigoManual").checked = !!m.pode_digitar_codigo_manual;
 
     document.getElementById("groupPassword").classList.add("d-none");
     document.getElementById("groupPasswordConfirm").classList.add("d-none");
@@ -633,6 +635,7 @@ function renderMotoboyDetail(data) {
     assign("d-cep", m.cep);
     assign("d-pode-coleta", m.pode_ler_coleta ? "Sim" : "Não");
     assign("d-pode-saida", m.pode_ler_saida !== false ? "Sim" : "Não");
+    assign("d-pode-codigo-manual", m.pode_digitar_codigo_manual ? "Sim" : "Não");
 
     wrap.classList.remove("d-none");
     document.getElementById("motoboy-empty")?.classList.add("d-none");
@@ -765,6 +768,7 @@ async function saveUser(ev) {
         payload.cep = (document.getElementById("cep").value || "").replace(/\D/g, "");
         payload.pode_ler_coleta = document.getElementById("podeLerColeta").checked;
         payload.pode_ler_saida = document.getElementById("podeLerSaida").checked;
+        payload.pode_digitar_codigo_manual = document.getElementById("podeDigitarCodigoManual").checked;
     }
 
     try {

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -577,8 +577,33 @@
   .pedido-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
   .pedido-codigo { font-size: 20px; font-weight: 600; }
   .pedido-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 15px; }
+  .pedido-grid-2 { grid-template-columns: minmax(260px, 0.9fr) minmax(320px, 1.1fr); }
+  @media (max-width: 900px) {
+    .pedido-grid-2 { grid-template-columns: 1fr; }
+  }
   .pedido-card { background: #ffffff; border-radius: 8px; padding: 15px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); }
   .pedido-card h5 { font-weight: 600; margin-bottom: 10px; }
+  .timeline-thumb-img { width: 80px; height: 80px; object-fit: cover; cursor: pointer; }
+  .timeline-thumb-btn:focus { outline: 2px solid #0d6efd; outline-offset: 2px; }
+  .reg-photo-lightbox {
+    position: fixed; inset: 0; z-index: 2100;
+    background: rgba(15, 23, 42, 0.82);
+    display: flex; align-items: center; justify-content: center;
+    padding: 24px;
+  }
+  .reg-photo-lightbox.d-none { display: none !important; }
+  .reg-photo-lightbox img {
+    max-width: min(960px, 100%);
+    max-height: 90vh;
+    object-fit: contain;
+    border-radius: 8px;
+    background: #fff;
+  }
+  .reg-photo-lightbox-close {
+    position: absolute; top: 16px; right: 20px;
+    border: 0; background: transparent; color: #fff;
+    font-size: 36px; line-height: 1; cursor: pointer;
+  }
   .status-badge { padding: 4px 10px; border-radius: 20px; font-size: 12px; font-weight: 600; }
   .status-success { background: #e6f7ee; color: #28a745; }
   .status-info { background: #e6f0ff; color: #007bff; }

--- a/Master/src/tracking-usuarios.html
+++ b/Master/src/tracking-usuarios.html
@@ -181,6 +181,10 @@
                                 <label class="form-label text-primary fw-medium mb-1">Pode ler Saídas</label>
                                 <div id="d-pode-saida">—</div>
                             </div>
+                            <div class="col-md-6">
+                                <label class="form-label text-primary fw-medium mb-1">Pode digitar código manual</label>
+                                <div id="d-pode-codigo-manual">—</div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -384,6 +388,14 @@
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="podeLerSaida" checked>
                                     <label class="form-check-label" for="podeLerSaida">Pode ler Saídas</label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <div class="mb-3">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="podeDigitarCodigoManual">
+                                    <label class="form-check-label" for="podeDigitarCodigoManual">Pode digitar código manualmente</label>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Objetivo
Melhorar a tela de Registros: timeline com fotos/motivo por evento, atalho para cancelar pedido bloqueado e ganhos de desempenho na listagem.

## Alterações
- Timeline com miniaturas de comprovante por evento de ausência/entrega
- Associação de fotos por data (`created_at`) e tentativa do momento
- Exibição de motivo/observação por evento (com fallback no detalhe atual)
- Atalho **Cancelar pedido** ao lado de **Liberar nova tentativa**
- Ao cancelar no editar/lote, não envia `motoboy_id` (evita bloqueio indevido)
- Compartilhar comprovante com texto/imagem enriquecidos e entregador na legenda
- Timeline com labels amigáveis; avulso limitado conforme permissão
- Cache em memória e listagem sem aguardar combos
- Busca por código exato após scan na câmera
- Motivo de ausência no detalhe de registros

## Testes realizados
- Validação de sintaxe do `tracking-registros.init.js`
- Fluxos manuais: detalhe com várias ausências (foto na 3ª tentativa); cancelar no detalhe; editar para Cancelado com bloqueio

## Impacto
- Frontend web `track_saidas_html` (Registros / Leitura)
- Depende do backend na mesma branch (`track_saidas`) para fotos tipadas, cancelamento com bloqueio e motivo no histórico
- Sem mudança de regra multi-tenant

## Rollback
Reverter o merge desta branch em `main`.

## Test plan
- [ ] Abrir detalhe de pedido com 2+ ausências e conferir foto sob cada tentativa
- [ ] Confirmar motivo na última ausência e, após deploy backend, em novas ausências
- [ ] Usar **Cancelar pedido** no detalhe com bloqueio por ausências
- [ ] Editar status para Cancelado sem erro de limite de tentativas
- [ ] Baixar/compartilhar comprovante
- [ ] Listagem rápida com filtros e busca por código