### PR TITLE
Cadastro de motoboy com digitação manual ativa por padrão

### DIFF
--- a/Master/src/assets/js/pages/tracking-usuarios.js
+++ b/Master/src/assets/js/pages/tracking-usuarios.js
@@ -529,7 +529,7 @@ function openCreate() {
     document.getElementById("estado").value = "";
     document.getElementById("podeLerColeta").checked = false;
     document.getElementById("podeLerSaida").checked = true;
-    document.getElementById("podeDigitarCodigoManual").checked = false;
+    document.getElementById("podeDigitarCodigoManual").checked = true;
 
     document.getElementById("groupPassword").classList.remove("d-none");
     document.getElementById("groupPasswordConfirm").classList.remove("d-none");

--- a/Master/src/tracking-usuarios.html
+++ b/Master/src/tracking-usuarios.html
@@ -394,8 +394,9 @@
                         <div class="col-12">
                             <div class="mb-3">
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="podeDigitarCodigoManual">
+                                    <input class="form-check-input" type="checkbox" id="podeDigitarCodigoManual" checked>
                                     <label class="form-check-label" for="podeDigitarCodigoManual">Pode digitar código manualmente</label>
+                                    <div class="form-text">Ativo por padrão. Desmarque só se precisar bloquear este entregador.</div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Objetivo
No cadastro/edição de usuários, deixar a digitação manual de código **ativa por padrão**, alinhado ao backend opt-out.

## Alterações
- Checkbox “Pode digitar código manualmente” inicia marcado
- Texto de ajuda: desmarcar só se precisar bloquear o entregador

## Testes realizados
- Conferência do reset do formulário de novo usuário
- Validação de sintaxe do JS

## Impacto
- Frontend web `track_saidas_html` (Usuários)
- Depende do backend com default/migration correspondente

## Rollback
Reverter o merge desta branch em `main`.

## Test plan
- [ ] Abrir “Novo usuário” (motoboy): checkbox de digitar já marcado
- [ ] Salvar sem alterar: API recebe `pode_digitar_codigo_manual: true`
- [ ] Desmarcar e salvar: permissão fica bloqueada