### PR TITLE
feat: exibe status Encerrado no histórico de registros

### DIFF
--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -527,6 +527,7 @@ function augmentEntregadoresFromRows(rows){
   function getStatusClass(status) {
     if (!status) return "status-default";
     var s = String(status).toLowerCase().replace(/_/g, " ");
+    if (s.indexOf("encerrado") !== -1) return "status-default";
     if (s.indexOf("entregue") !== -1) return "status-success";
     if (s.indexOf("ausente") !== -1) return "status-warning";
     if (s.indexOf("cancelado") !== -1) return "status-danger";
@@ -539,6 +540,9 @@ function augmentEntregadoresFromRows(rows){
     var s = String(status).replace(/_/g, " ").trim();
     var lower = s.toLowerCase();
     if (lower === "saiu" || lower === "saiu para entrega") return "SAIU PARA ENTREGA";
+    if (lower === "encerrado sistema" || lower === "encerrado pelo sistema" || lower === "encerrado_sistema") {
+      return "Encerrado pelo sistema";
+    }
     return s.toUpperCase();
   }
 
@@ -593,7 +597,9 @@ function augmentEntregadoresFromRows(rows){
     removido_sem_inicio: "Removido antes de iniciar rota",
     endereco_atualizado: "Endereço atualizado",
     rota_criada: "Inserido na rota",
-    rota_recalculada: "Rota recalculada"
+    rota_recalculada: "Rota recalculada",
+    encerrado_sistema: "Encerrado pelo sistema",
+    rota_cancelada: "Rota cancelada"
   };
 
   function normalizeEventoKey(evento) {
@@ -1820,20 +1826,33 @@ function setupPagerEvents() {
     if (eSrv) eSrv.value = normalizeServicoForEdit(row.servico, row.codigo);
 
     var uiStatus = (() => {
-      var s = (row.status || "").toLowerCase();
+      var s = (row.status || "").toLowerCase().replace(/_/g, " ");
       if (s === "saiu" || s === "saiu para entrega") return "Saiu para entrega";
-      if (s === "em_rota" || s === "em rota") return "Saiu para entrega";
+      if (s === "em rota" || s === "em_rota") return "Saiu para entrega";
       if (s === "coletado") return "Coletado";
       if (s === "nao coletado" || s === "não coletado") return "Não Coletado";
       if (s === "cancelado") return "Cancelado";
       if (s === "entregue") return "Entregue";
       if (s === "ausente") return "Ausente";
+      if (s.indexOf("encerrado") !== -1) return "Encerrado pelo sistema";
       return "Saiu para entrega";
     })();
 
     if (eSta) {
-      var statusAllowed = getAllowedStatusOptions().some(function(opt){ return opt.value === uiStatus; });
-      eSta.value = statusAllowed ? uiStatus : "Saiu para entrega";
+      // Encerrado não é escolhível; só aparece se for o status atual (exibição).
+      if (uiStatus === "Encerrado pelo sistema") {
+        var hasEnc = Array.from(eSta.options || []).some(function(o){ return o.value === uiStatus; });
+        if (!hasEnc) {
+          var optEnc = document.createElement("option");
+          optEnc.value = "Encerrado pelo sistema";
+          optEnc.textContent = "Encerrado pelo sistema";
+          eSta.insertBefore(optEnc, eSta.firstChild);
+        }
+        eSta.value = uiStatus;
+      } else {
+        var statusAllowed = getAllowedStatusOptions().some(function(opt){ return opt.value === uiStatus; });
+        eSta.value = statusAllowed ? uiStatus : "Saiu para entrega";
+      }
     }
     if (eBase) eBase.value = row.base || "";
 
@@ -1915,6 +1934,7 @@ function setupPagerEvents() {
           v === "Cancelado"         ? "cancelado" :
           v === "Entregue"          ? "entregue" :
           v === "Ausente"           ? "ausente" :
+          v === "Encerrado pelo sistema" ? "ENCERRADO_SISTEMA" :
           "saiu"
         );
       }
@@ -2026,11 +2046,12 @@ function setupPagerEvents() {
   var bulkCurrentCohortStatus = "";
 
   function normalizeStatusForBulk(rawStatus){
-    var s = String(rawStatus || "").toLowerCase().trim();
-    if (s === "saiu para entrega" || s === "saiu_pra_entrega" || s === "saiu") return "saiu";
-    if (s === "em rota" || s === "em_rota") return "em_rota";
+    var s = String(rawStatus || "").toLowerCase().trim().replace(/_/g, " ");
+    if (s === "saiu para entrega" || s === "saiu pra entrega" || s === "saiu") return "saiu";
+    if (s === "em rota") return "em_rota";
     if (s === "entregue") return "entregue";
     if (s === "ausente") return "ausente";
+    if (s.indexOf("encerrado") !== -1) return "encerrado_sistema";
     return s;
   }
 

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -540,8 +540,8 @@ function augmentEntregadoresFromRows(rows){
     var s = String(status).replace(/_/g, " ").trim();
     var lower = s.toLowerCase();
     if (lower === "saiu" || lower === "saiu para entrega") return "SAIU PARA ENTREGA";
-    if (lower === "encerrado sistema" || lower === "encerrado pelo sistema" || lower === "encerrado_sistema") {
-      return "Encerrado pelo sistema";
+    if (lower === "encerrado sistema" || lower === "encerrado pelo sistema" || lower === "encerrado_sistema" || lower === "encerrado") {
+      return "Encerrado";
     }
     return s.toUpperCase();
   }
@@ -606,12 +606,14 @@ function augmentEntregadoresFromRows(rows){
     var raw = String(evento || "").trim().toLowerCase().replace(/\s+/g, "_");
     if (!raw) return "unknown";
     if (Object.prototype.hasOwnProperty.call(EVENTO_HISTORICO_LABELS, raw)) return raw;
+    if (raw.indexOf("encerrado") !== -1) return "encerrado_sistema";
     if (raw.indexOf("entregue") !== -1) return "entregue";
     if (raw.indexOf("ausente") !== -1) return "ausente";
     if (raw.indexOf("cancel") !== -1) return "cancelado";
     if (raw.indexOf("endereco") !== -1) return "endereco_atualizado";
     if (raw.indexOf("recalcul") !== -1) return "rota_recalculada";
     if (raw.indexOf("rota_criada") !== -1 || raw === "rota_criada") return "rota_criada";
+    if (raw === "rota_cancelada" || raw.indexOf("rota_cancel") !== -1) return "rota_cancelada";
     if (raw.indexOf("rota") !== -1 || raw === "saiu") return raw === "saiu" ? "saiu" : "em_rota";
     if (raw.indexOf("scan") !== -1 || raw.indexOf("escane") !== -1) return "scan";
     if (raw.indexOf("lido") !== -1 || raw.indexOf("leitura") !== -1) return "lido";
@@ -1834,18 +1836,18 @@ function setupPagerEvents() {
       if (s === "cancelado") return "Cancelado";
       if (s === "entregue") return "Entregue";
       if (s === "ausente") return "Ausente";
-      if (s.indexOf("encerrado") !== -1) return "Encerrado pelo sistema";
+      if (s.indexOf("encerrado") !== -1) return "Encerrado";
       return "Saiu para entrega";
     })();
 
     if (eSta) {
       // Encerrado não é escolhível; só aparece se for o status atual (exibição).
-      if (uiStatus === "Encerrado pelo sistema") {
+      if (uiStatus === "Encerrado") {
         var hasEnc = Array.from(eSta.options || []).some(function(o){ return o.value === uiStatus; });
         if (!hasEnc) {
           var optEnc = document.createElement("option");
-          optEnc.value = "Encerrado pelo sistema";
-          optEnc.textContent = "Encerrado pelo sistema";
+          optEnc.value = "Encerrado";
+          optEnc.textContent = "Encerrado";
           eSta.insertBefore(optEnc, eSta.firstChild);
         }
         eSta.value = uiStatus;
@@ -1934,7 +1936,7 @@ function setupPagerEvents() {
           v === "Cancelado"         ? "cancelado" :
           v === "Entregue"          ? "entregue" :
           v === "Ausente"           ? "ausente" :
-          v === "Encerrado pelo sistema" ? "ENCERRADO_SISTEMA" :
+          v === "Encerrado" ? "ENCERRADO_SISTEMA" :
           "saiu"
         );
       }

--- a/Master/src/auth-signin-tracking-v2.html
+++ b/Master/src/auth-signin-tracking-v2.html
@@ -142,7 +142,7 @@
               <p class="mb-0">&copy; <script>document.write(new Date().getFullYear())</script> Tracking Saídas</p>
             </div>
             <div class="col-6 text-end">
-              <p class="mb-0">v4.6.0</p>
+              <p class="mb-0">v4.7.0</p>
             </div>
           </div>
         </div>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -133,6 +133,10 @@
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-cancelado" value="cancelado">
                                   <label class="form-check-label small" for="flt-status-cancelado">Cancelado</label>
                                 </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-encerrado" value="encerrado_sistema">
+                                  <label class="form-check-label small" for="flt-status-encerrado">Encerrado pelo sistema</label>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -135,7 +135,7 @@
                                 </div>
                                 <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-encerrado" value="encerrado_sistema">
-                                  <label class="form-check-label small" for="flt-status-encerrado">Encerrado pelo sistema</label>
+                                  <label class="form-check-label small" for="flt-status-encerrado">Encerrado</label>
                                 </div>
                               </div>
                             </div>


### PR DESCRIPTION
## Resumo

Exibe o status Encerrado pelo sistema no histórico de registros, separado da ação operacional, alinhado ao backend de encerramento por quinzenas (v4.7.0).

## Tipo de alteração

- [x] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Exibe status encerrado pelo sistema no tracking de registros.
- Separa visualmente o status Encerrado da ação no histórico.

## Como testar

- Abrir histórico/registros com pedidos encerrados pelo sistema.
- Confirmar que Encerrado aparece distinto da ação (ex.: bipagem/entrega).
- Validar com backend da mesma branch (`feat/release-1-5-encerramento-quinzenas`).

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

### Rollback

- Reverter esta PR; histórico volta ao comportamento anterior de status.

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

Made with [Cursor](https://cursor.com)