### PR TITLE
feat: toggle de devolução pelo app na edição de Owners

### DIFF
--- a/Master/src/admin-owners.html
+++ b/Master/src/admin-owners.html
@@ -181,6 +181,14 @@
                         </div>
 
                         <div class="col-12">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" id="ownerDevolucaoToggle">
+                                <label class="form-check-label">Permitir devolução de pacotes pelo app do entregador (com foto)</label>
+                            </div>
+                            <small class="text-muted d-block mt-1">Quando ativo, o motoboy vê o atalho Devolver pacotes e pode cancelar com comprovante.</small>
+                        </div>
+
+                        <div class="col-12">
                             <label class="form-label">Modo de Operação</label>
                             <select id="ownerModoOperacao" class="form-select">
                                 <option value="codigo">Coletas e Saída via código</option>

--- a/Master/src/assets/js/pages/admin-owners.js
+++ b/Master/src/assets/js/pages/admin-owners.js
@@ -315,6 +315,7 @@ function openEdit(o) {
     document.getElementById("ownerValor").value = Number(o.valor).toFixed(2);
 
     document.getElementById("ownerIgnorarToggle").checked = o.ignorar_coleta;
+    document.getElementById("ownerDevolucaoToggle").checked = !!o.devolucao_sub_base_habilitada;
     document.getElementById("ownerModoOperacao").value = o.modo_operacao || "codigo";
     document.getElementById("ownerTesteToggle").checked = !!o.teste;
     document.getElementById("ownerAtivoToggle").checked = o.ativo;
@@ -342,6 +343,7 @@ document.getElementById("formOwner").addEventListener("submit", async (ev) => {
         valor: Number(document.getElementById("ownerValor").value),
         modo_operacao: document.getElementById("ownerModoOperacao").value || "codigo",
         ignorar_coleta: document.getElementById("ownerIgnorarToggle").checked,
+        devolucao_sub_base_habilitada: document.getElementById("ownerDevolucaoToggle").checked,
         teste: document.getElementById("ownerTesteToggle").checked,
         ativo: document.getElementById("ownerAtivoToggle").checked,
         tipo_owner: (document.getElementById("ownerTipo").value || "subbase").toLowerCase()


### PR DESCRIPTION
## Resumo

Adiciona toggle na edição de Owners para habilitar devolução de pacotes pelo app mobile à sub_base.

## Tipo de alteração

- [x] feature
- [ ] fix
- [ ] bug
- [ ] chore
- [ ] docs
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Campo/toggle `devolucao_sub_base_habilitada` na edição de Owners
- Persistência junto ao restante das configs do owner

## Como testar

- Editar Owner → ativar/desativar devolução pelo app → salvar
- Relogin no mobile e conferir presença/ausência do atalho Devolver pacotes

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [ ] Altera banco/migração
- [ ] Altera autenticação/permissões
- [ ] Altera integração externa
- [ ] Requer variável de ambiente

**Dependência:** backend com coluna/migration e claim JWT.

## Checklist

- [x] Testei localmente
- [x] Revisei arquivos sensíveis como `.env`, tokens e chaves
- [ ] Atualizei documentação, se necessário
- [ ] Adicionei/atualizei migração, se necessário

Made with [Cursor](https://cursor.com)