### PR TITLE
feat: registrar entrada, conferência e permissão de avulso na web

### DIFF
--- a/Master/src/admin-owners.html
+++ b/Master/src/admin-owners.html
@@ -189,6 +189,22 @@
                         </div>
 
                         <div class="col-12">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" id="ownerEntradaToggle">
+                                <label class="form-check-label">Exigir entrada na base antes da saída</label>
+                            </div>
+                            <small class="text-muted d-block mt-1">Quando ativo, o operador registra entrada e a saída só é permitida com entrada prévia.</small>
+                        </div>
+
+                        <div class="col-12">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" id="ownerConferenciaToggle">
+                                <label class="form-check-label">Habilitar conferência de saída</label>
+                            </div>
+                            <small class="text-muted d-block mt-1">Quando ativo, após o motoboy começar a entrega a saída fica pendente de conferência operacional.</small>
+                        </div>
+
+                        <div class="col-12">
                             <label class="form-label">Modo de Operação</label>
                             <select id="ownerModoOperacao" class="form-select">
                                 <option value="codigo">Coletas e Saída via código</option>

--- a/Master/src/assets/js/pages/admin-owners.js
+++ b/Master/src/assets/js/pages/admin-owners.js
@@ -316,6 +316,8 @@ function openEdit(o) {
 
     document.getElementById("ownerIgnorarToggle").checked = o.ignorar_coleta;
     document.getElementById("ownerDevolucaoToggle").checked = !!o.devolucao_sub_base_habilitada;
+    document.getElementById("ownerEntradaToggle").checked = !!o.entrada_obrigatoria_habilitada;
+    document.getElementById("ownerConferenciaToggle").checked = !!o.conferencia_saida_habilitada;
     document.getElementById("ownerModoOperacao").value = o.modo_operacao || "codigo";
     document.getElementById("ownerTesteToggle").checked = !!o.teste;
     document.getElementById("ownerAtivoToggle").checked = o.ativo;
@@ -344,6 +346,8 @@ document.getElementById("formOwner").addEventListener("submit", async (ev) => {
         modo_operacao: document.getElementById("ownerModoOperacao").value || "codigo",
         ignorar_coleta: document.getElementById("ownerIgnorarToggle").checked,
         devolucao_sub_base_habilitada: document.getElementById("ownerDevolucaoToggle").checked,
+        entrada_obrigatoria_habilitada: document.getElementById("ownerEntradaToggle").checked,
+        conferencia_saida_habilitada: document.getElementById("ownerConferenciaToggle").checked,
         teste: document.getElementById("ownerTesteToggle").checked,
         ativo: document.getElementById("ownerAtivoToggle").checked,
         tipo_owner: (document.getElementById("ownerTipo").value || "subbase").toLowerCase()

--- a/Master/src/assets/js/pages/tracking-acompanhamento.init.js
+++ b/Master/src/assets/js/pages/tracking-acompanhamento.init.js
@@ -145,6 +145,18 @@
       const tier = Op.slaTier ? Op.slaTier(sla) : "neutral";
       bar.className = "acom-sla-bar__fill acom-sla-bar__fill--" + tier;
     }
+
+    const cardEntrada = qs("#card-entrada-saida");
+    if (cardEntrada) {
+      const habilitada = !!totais.entrada_habilitada;
+      cardEntrada.classList.toggle("d-none", !habilitada);
+      if (habilitada) {
+        set("kpi-entradas", String(totais.entradas ?? 0));
+        set("kpi-saidas-entrada", String(totais.saidas ?? 0));
+        const pctEnt = totais.pct_saida_sobre_entrada;
+        set("kpi-pct-entrada", pctEnt != null ? `${Number(pctEnt).toFixed(1)}%` : "—");
+      }
+    }
   }
 
   function setQuickFilter(filter) {

--- a/Master/src/assets/js/pages/tracking-entrada-leitura.init.js
+++ b/Master/src/assets/js/pages/tracking-entrada-leitura.init.js
@@ -116,10 +116,29 @@
     if (ok) updateResumo(data);
   }
 
+  const SCAN_DEBOUNCE_MS = 1500;
+  const recentCodes = new Map();
+  function isRecentlyScanned(codigo) {
+    const key = String(codigo || "").trim();
+    if (!key) return true;
+    const ts = recentCodes.get(key) || 0;
+    return Date.now() - ts < SCAN_DEBOUNCE_MS;
+  }
+  function markScanned(codigo) {
+    const key = String(codigo || "").trim();
+    if (key) recentCodes.set(key, Date.now());
+  }
+
   async function registrarCodigo(raw, origem) {
     const codigo = String(raw || "").trim();
-    if (!codigo || busy) return;
+    if (!codigo || busy) return { ok: false, tipo: "busy" };
+
+    if (origem === "camera" && isRecentlyScanned(codigo)) {
+      return { ok: false, tipo: "debounce" };
+    }
+
     busy = true;
+    markScanned(codigo);
     try {
       const { ok, data, status } = await req("/entradas/ler", {
         method: "POST",
@@ -128,27 +147,28 @@
 
       if (status === 401) {
         showMsg("erro", "Sessão expirada. Faça login novamente.");
-        return;
+        return { ok: false, tipo: "auth" };
       }
       if (status === 403) {
         const msg = data?.detail?.message || data?.detail || "Acesso negado.";
         showMsg("erro", typeof msg === "string" ? msg : "Acesso negado.");
-        return;
+        return { ok: false, tipo: "forbidden" };
       }
       if (status === 409 && (data?.code === "JA_NA_BASE" || data?.detail?.code === "JA_NA_BASE")) {
         showMsg("alerta", data?.message || data?.detail?.message || "Pacote já teve entrada na base.");
-        return;
+        return { ok: false, tipo: "duplicado" };
       }
       if (!ok) {
         const msg = data?.message || data?.detail?.message || data?.detail || "Falha ao registrar entrada.";
         showMsg("erro", typeof msg === "string" ? msg : "Falha ao registrar entrada.");
-        return;
+        return { ok: false, tipo: "erro" };
       }
 
       setUltima(data.codigo || codigo, data.servico || "");
       showMsg("info", `Entrada registrada ✓ ${data.codigo || codigo}`);
       if (inpCod) { inpCod.value = ""; inpCod.focus(); }
       await refreshResumo();
+      return { ok: true, tipo: "ok" };
     } finally {
       busy = false;
     }
@@ -205,7 +225,7 @@
     await refreshResumo();
   });
 
-  // Scanner câmera (BarcodeDetector quando disponível)
+  // Scanner câmera sequencial (mesmo padrão de Registrar Saídas)
   (function scanner() {
     const btnScan = $("btnScan");
     const overlay = $("scanFS");
@@ -216,19 +236,53 @@
 
     let stream = null;
     let timer = null;
-    let locked = false;
+    let scanLocked = false;
+    let zxingReader = null;
 
     async function stop() {
-      locked = false;
+      scanLocked = false;
       if (timer) { clearInterval(timer); timer = null; }
+      if (zxingReader) {
+        try { zxingReader.reset(); } catch (_) {}
+        zxingReader = null;
+      }
       if (stream) {
         stream.getTracks().forEach((t) => t.stop());
         stream = null;
       }
       video.srcObject = null;
       overlay.classList.remove("show");
+      overlay.classList.remove("scan-lock");
       overlay.style.display = "none";
       inpCod?.focus();
+    }
+
+    async function processarCodigo(text) {
+      const codigo = String(text || "").trim();
+      if (!codigo || scanLocked || busy) return;
+      if (isRecentlyScanned(codigo)) return;
+
+      scanLocked = true;
+      overlay.classList.add("scan-lock");
+      if (hud) hud.textContent = "Processando…";
+      if (inpCod) inpCod.value = codigo;
+
+      try {
+        const result = await registrarCodigo(codigo, "camera");
+        if (result?.ok) {
+          if (hud) hud.textContent = "OK — próximo código";
+        } else if (result?.tipo === "duplicado") {
+          if (hud) hud.textContent = "Já na base — próximo";
+        } else if (result?.tipo !== "debounce") {
+          if (hud) hud.textContent = "Erro — tente outro";
+        }
+      } finally {
+        overlay.classList.remove("scan-lock");
+        setTimeout(() => {
+          scanLocked = false;
+          if (hud) hud.textContent = "Aponte para o código";
+        }, 200);
+      }
     }
 
     async function start() {
@@ -244,30 +298,48 @@
         if (hud) hud.textContent = "Aponte para o código";
 
         if ("BarcodeDetector" in window) {
-          const detector = new BarcodeDetector({ formats: ["qr_code", "code_128", "ean_13", "code_39"] });
-          timer = setInterval(async () => {
-            if (locked || busy) return;
-            try {
-              const codes = await detector.detect(video);
-              if (!codes?.length) return;
-              const raw = codes[0].rawValue;
-              if (!raw) return;
-              locked = true;
-              if (hud) hud.textContent = "Lendo…";
-              await registrarCodigo(raw, "camera");
-              setTimeout(() => { locked = false; if (hud) hud.textContent = "Aponte para o código"; }, 900);
-            } catch (_) {}
-          }, 350);
+          try {
+            const detector = new BarcodeDetector({
+              formats: ["qr_code", "ean_13", "code_128", "code_39", "itf", "upc_a", "upc_e"],
+            });
+            timer = setInterval(async () => {
+              if (scanLocked || busy) return;
+              try {
+                const barcodes = await detector.detect(video);
+                if (barcodes.length) processarCodigo(barcodes[0].rawValue || "");
+              } catch (_) {}
+            }, 120);
+            return;
+          } catch (_) {}
+        }
+
+        if (window.ZXingBrowser) {
+          zxingReader = new ZXingBrowser.BrowserMultiFormatReader();
+          try {
+            await zxingReader.decodeFromVideoDevice(null, video, (result) => {
+              if (result) processarCodigo(result.getText());
+            });
+          } catch (_) {
+            if (hud) hud.textContent = "Leitor não suportado. Use bipe USB.";
+          }
         } else if (hud) {
-          hud.textContent = "Câmera sem detector nativo. Digite o código ou use bipe USB.";
+          hud.textContent = "Câmera sem detector. Digite o código ou use bipe USB.";
         }
       } catch (e) {
         await Swal.fire({ icon: "error", title: "Câmera", text: "Não foi possível acessar a câmera." });
       }
     }
 
-    btnScan.addEventListener("click", () => start());
-    closeBtn?.addEventListener("click", () => stop());
+    btnScan.addEventListener("click", (e) => {
+      e.preventDefault();
+      start();
+    });
+    closeBtn?.addEventListener("click", (e) => {
+      e.preventDefault();
+      stop();
+    });
+    window.entradaStartScanner = start;
+    window.entradaStopScanner = stop;
   })();
 
   applyModo();

--- a/Master/src/assets/js/pages/tracking-entrada-leitura.init.js
+++ b/Master/src/assets/js/pages/tracking-entrada-leitura.init.js
@@ -1,0 +1,278 @@
+// assets/js/pages/tracking-entrada-leitura.init.js
+(async function () {
+  "use strict";
+
+  function apiBase() {
+    let base = (window.TRACK_API_URL || "").replace(/\/+$/, "");
+    if (!base.endsWith("/api")) base += "/api";
+    return base;
+  }
+
+  const $ = (id) => document.getElementById(id);
+  const inpCod = $("codigo");
+  const btnReg = $("btnRegistrar");
+  const btnAvulso = $("btnLancarAvulso");
+  const msgArea = $("msgArea");
+  let modoMonitor = false;
+  let busy = false;
+
+  try {
+    if (localStorage.getItem("entradaModoMonitor") === "1") modoMonitor = true;
+  } catch (_) {}
+
+  function showMsg(tipo, text) {
+    if (!msgArea) return;
+    const cls =
+      tipo === "erro" ? "alert-danger" :
+      tipo === "alerta" ? "alert-warning" :
+      "alert-success";
+    msgArea.innerHTML = `<div class="alert ${cls} mb-0 py-2">${text}</div>`;
+  }
+
+  function setText(id, val) {
+    const el = $(id);
+    if (el) el.textContent = val;
+  }
+
+  function applyModo() {
+    const padrao = $("modo-padrao");
+    const monitor = $("modo-monitor");
+    if (padrao) padrao.classList.toggle("d-none", modoMonitor);
+    if (monitor) monitor.classList.toggle("d-none", !modoMonitor);
+    const btn = $("btnModoMonitor");
+    const btnText = $("btnModoMonitorText");
+    if (btn) {
+      btn.classList.toggle("btn-outline-primary", !modoMonitor);
+      btn.classList.toggle("btn-primary", modoMonitor);
+    }
+    if (btnText) btnText.textContent = modoMonitor ? "Modo Padrão" : "Modo Monitor";
+    if (modoMonitor && inpCod) inpCod.focus();
+  }
+
+  $("btnModoMonitor")?.addEventListener("click", () => {
+    modoMonitor = !modoMonitor;
+    try { localStorage.setItem("entradaModoMonitor", modoMonitor ? "1" : "0"); } catch (_) {}
+    applyModo();
+  });
+
+  async function req(path, opts) {
+    const res = await fetch(apiBase() + path, Object.assign({
+      credentials: "include",
+      headers: { "Accept": "application/json", "Content-Type": "application/json" },
+    }, opts || {}));
+    let data = null;
+    try { data = await res.json(); } catch (_) {}
+    return { res, data, ok: res.ok, status: res.status };
+  }
+
+  async function ensureEntradaHabilitada() {
+    const { ok, data, status } = await req("/auth/me", { method: "GET", headers: { "Accept": "application/json" } });
+    if (status === 401) {
+      location.href = "login.html";
+      return false;
+    }
+    if (!ok) return true;
+    if (!data?.entrada_obrigatoria_habilitada) {
+      await Swal.fire({
+        icon: "info",
+        title: "Entrada não habilitada",
+        text: "Registrar Entrada não está ativo para esta base.",
+      });
+      location.href = "tracking-leitura.html";
+      return false;
+    }
+    return true;
+  }
+
+  function updateResumo(r) {
+    const shopee = r?.sum_shopee ?? 0;
+    const ml = r?.sum_mercado ?? 0;
+    const avulso = r?.sum_avulso ?? 0;
+    const total = r?.total ?? (shopee + ml + avulso);
+    setText("sum-shopee", String(shopee));
+    setText("sum-ml", String(ml));
+    setText("sum-avulso", String(avulso));
+    setText("sum-total", String(total));
+    setText("monitor-shopee", String(shopee));
+    setText("monitor-ml", String(ml));
+    setText("monitor-avulso", String(avulso));
+    setText("monitor-total", String(total));
+  }
+
+  function setUltima(codigo, servico) {
+    const hora = new Date().toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    setText("ultima-codigo", codigo || "—");
+    setText("ultima-hora", hora);
+    setText("monitor-ultima-codigo", codigo || "—");
+    const badge = $("ultima-servico");
+    const badgeM = $("monitor-ultima-servico");
+    const label = servico || "—";
+    if (badge) badge.textContent = label;
+    if (badgeM) badgeM.textContent = label;
+  }
+
+  async function refreshResumo() {
+    const { ok, data } = await req("/entradas/resumo-dia");
+    if (ok) updateResumo(data);
+  }
+
+  async function registrarCodigo(raw, origem) {
+    const codigo = String(raw || "").trim();
+    if (!codigo || busy) return;
+    busy = true;
+    try {
+      const { ok, data, status } = await req("/entradas/ler", {
+        method: "POST",
+        body: JSON.stringify({ codigo, origem: origem || "manual" }),
+      });
+
+      if (status === 401) {
+        showMsg("erro", "Sessão expirada. Faça login novamente.");
+        return;
+      }
+      if (status === 403) {
+        const msg = data?.detail?.message || data?.detail || "Acesso negado.";
+        showMsg("erro", typeof msg === "string" ? msg : "Acesso negado.");
+        return;
+      }
+      if (status === 409 && (data?.code === "JA_NA_BASE" || data?.detail?.code === "JA_NA_BASE")) {
+        showMsg("alerta", data?.message || data?.detail?.message || "Pacote já teve entrada na base.");
+        return;
+      }
+      if (!ok) {
+        const msg = data?.message || data?.detail?.message || data?.detail || "Falha ao registrar entrada.";
+        showMsg("erro", typeof msg === "string" ? msg : "Falha ao registrar entrada.");
+        return;
+      }
+
+      setUltima(data.codigo || codigo, data.servico || "");
+      showMsg("info", `Entrada registrada ✓ ${data.codigo || codigo}`);
+      if (inpCod) { inpCod.value = ""; inpCod.focus(); }
+      await refreshResumo();
+    } finally {
+      busy = false;
+    }
+  }
+
+  btnReg?.addEventListener("click", () => registrarCodigo(inpCod?.value, "manual"));
+  inpCod?.addEventListener("keydown", (ev) => {
+    if (ev.key === "Enter") {
+      ev.preventDefault();
+      registrarCodigo(inpCod.value, "manual");
+    }
+  });
+
+  btnAvulso?.addEventListener("click", async () => {
+    const { value: formValues } = await Swal.fire({
+      title: "Lançar Avulso (entrada)",
+      html:
+        '<input id="swal-ident" class="swal2-input" placeholder="Identificação (opcional)">' +
+        '<input id="swal-qtd" type="number" min="1" max="50" value="1" class="swal2-input" placeholder="Quantidade">',
+      focusConfirm: false,
+      showCancelButton: true,
+      confirmButtonText: "Criar",
+      cancelButtonText: "Cancelar",
+      preConfirm: () => {
+        const qtd = Number(document.getElementById("swal-qtd").value || 0);
+        if (!qtd || qtd < 1) {
+          Swal.showValidationMessage("Informe a quantidade.");
+          return false;
+        }
+        return {
+          identificacao: (document.getElementById("swal-ident").value || "").trim() || null,
+          quantidade: qtd,
+        };
+      },
+    });
+    if (!formValues) return;
+
+    const { ok, data, status } = await req("/entradas/lancar-avulso", {
+      method: "POST",
+      body: JSON.stringify(formValues),
+    });
+    if (!ok) {
+      const msg = data?.detail?.message || data?.detail || data?.mensagem || "Falha ao lançar avulso.";
+      await Swal.fire({ icon: "error", title: "Erro", text: typeof msg === "string" ? msg : "Falha ao lançar avulso." });
+      return;
+    }
+    const codigos = Array.isArray(data?.codigos) ? data.codigos : [];
+    if (codigos.length) setUltima(codigos[codigos.length - 1], "Avulso");
+    await Swal.fire({
+      icon: "success",
+      title: "Avulso criado",
+      text: data?.mensagem || `${data?.quantidade_criada || formValues.quantidade} pacote(s) na base.`,
+    });
+    await refreshResumo();
+  });
+
+  // Scanner câmera (BarcodeDetector quando disponível)
+  (function scanner() {
+    const btnScan = $("btnScan");
+    const overlay = $("scanFS");
+    const video = $("scanFSVideo");
+    const hud = $("scanFSMsg");
+    const closeBtn = $("scanCloseBtn");
+    if (!btnScan || !overlay || !video) return;
+
+    let stream = null;
+    let timer = null;
+    let locked = false;
+
+    async function stop() {
+      locked = false;
+      if (timer) { clearInterval(timer); timer = null; }
+      if (stream) {
+        stream.getTracks().forEach((t) => t.stop());
+        stream = null;
+      }
+      video.srcObject = null;
+      overlay.classList.remove("show");
+      overlay.style.display = "none";
+      inpCod?.focus();
+    }
+
+    async function start() {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: { ideal: "environment" } },
+          audio: false,
+        });
+        video.srcObject = stream;
+        await video.play();
+        overlay.style.display = "block";
+        overlay.classList.add("show");
+        if (hud) hud.textContent = "Aponte para o código";
+
+        if ("BarcodeDetector" in window) {
+          const detector = new BarcodeDetector({ formats: ["qr_code", "code_128", "ean_13", "code_39"] });
+          timer = setInterval(async () => {
+            if (locked || busy) return;
+            try {
+              const codes = await detector.detect(video);
+              if (!codes?.length) return;
+              const raw = codes[0].rawValue;
+              if (!raw) return;
+              locked = true;
+              if (hud) hud.textContent = "Lendo…";
+              await registrarCodigo(raw, "camera");
+              setTimeout(() => { locked = false; if (hud) hud.textContent = "Aponte para o código"; }, 900);
+            } catch (_) {}
+          }, 350);
+        } else if (hud) {
+          hud.textContent = "Câmera sem detector nativo. Digite o código ou use bipe USB.";
+        }
+      } catch (e) {
+        await Swal.fire({ icon: "error", title: "Câmera", text: "Não foi possível acessar a câmera." });
+      }
+    }
+
+    btnScan.addEventListener("click", () => start());
+    closeBtn?.addEventListener("click", () => stop());
+  })();
+
+  applyModo();
+  const ok = await ensureEntradaHabilitada();
+  if (!ok) return;
+  await refreshResumo();
+  inpCod?.focus();
+})();

--- a/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
@@ -67,6 +67,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       valorBase: 0,
       g_por_servico: { shopee: 0, ml: 0, avulso: 0 },
       g_total: 0,
+      conferencia_habilitada: false,
+      conferencia_por_dia: [],
     },
     contextoFechamento: null, // { status, id_fechamento, periodo_inicio, periodo_fim, entregador_nome } quando um único entregador
     entregadoresParaReajuste: [], // quando status GERADO sem entregador no filtro: lista de { entregador_id, entregador_nome, id_fechamento, periodo_inicio, periodo_fim }
@@ -438,6 +440,37 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
   }
 
+  function formatarDataYmd(ymd) {
+    if (!ymd) return "—";
+    const [y, m, d] = String(ymd).split("-");
+    return d && m && y ? `${d}/${m}/${y}` : String(ymd);
+  }
+
+  function renderConferenciaBox(lista, habilitada) {
+    const box = qs("#fech-conferencia-box");
+    const tbodyConf = qs("#fech-conferencia-tbody");
+    if (!box || !tbodyConf) return;
+    const rows = Array.isArray(lista) ? lista : [];
+    if (!habilitada) {
+      box.classList.add("d-none");
+      tbodyConf.innerHTML = "";
+      return;
+    }
+    box.classList.remove("d-none");
+    if (!rows.length) {
+      tbodyConf.innerHTML = '<tr><td colspan="2" class="text-muted small">Sem dias com conferência no período.</td></tr>';
+      return;
+    }
+    tbodyConf.innerHTML = rows
+      .map((r) => {
+        const dataBr = formatarDataYmd(r.data);
+        const label = r.label || (r.status === "conferida" ? "Conferido" : "Não conferido");
+        const cls = r.status === "conferida" ? "text-success" : "text-danger";
+        return `<tr><td class="text-nowrap">${dataBr}</td><td class="${cls} fw-semibold">${label}</td></tr>`;
+      })
+      .join("");
+  }
+
   async function abrirModalFechamento(modoEdicao, idFech, executorTipo, executorId, periodoInicio, periodoFim, entNome) {
     state.modoEdicao = !!modoEdicao;
     state.divergenciaValorBase = false;
@@ -471,6 +504,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const alertDiverg = qs("#fechamentoAlertaDivergencia");
     if (alertDiverg) alertDiverg.classList.add("d-none");
+    state.fechModal.conferencia_habilitada = false;
+    state.fechModal.conferencia_por_dia = [];
+    renderConferenciaBox([], false);
 
     if (state.modoEdicao && idFech) {
       try {
@@ -523,6 +559,11 @@ document.addEventListener("DOMContentLoaded", async () => {
           qs("#fech-valor-base").value = formatarMoeda(data.valor_base);
           state.fechModal.g_por_servico = data.g_por_servico || { shopee: 0, ml: 0, avulso: 0 };
           state.fechModal.g_total = data.g_total ?? 0;
+          state.fechModal.conferencia_habilitada = !!data.conferencia_habilitada;
+          state.fechModal.conferencia_por_dia = Array.isArray(data.conferencia_por_dia)
+            ? data.conferencia_por_dia
+            : [];
+          renderConferenciaBox(state.fechModal.conferencia_por_dia, state.fechModal.conferencia_habilitada);
         } else {
           let mensagem = "Erro ao calcular fechamento.";
           try {
@@ -642,6 +683,39 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (a.motivo) motivoSubtracao += (motivoSubtracao ? " | " : "") + a.motivo;
       }
     });
+
+    if (!state.modoEdicao && !idFech && state.fechModal.conferencia_habilitada) {
+      const naoConferidos = (state.fechModal.conferencia_por_dia || []).filter(
+        (d) => d && d.status !== "conferida"
+      );
+      if (naoConferidos.length > 0) {
+        const datas = naoConferidos
+          .map((d) => formatarDataYmd(d.data))
+          .filter(Boolean)
+          .join(", ");
+        if (window.Swal) {
+          const conf = await Swal.fire({
+            icon: "warning",
+            title: "Há dia(s) sem conferência de saída",
+            html:
+              `<p class="mb-2">Dias não conferidos: <strong>${datas || "—"}</strong></p>` +
+              `<p class="mb-0">Deseja continuar e gerar o fechamento mesmo assim?</p>`,
+            showCancelButton: true,
+            confirmButtonText: "Gerar mesmo assim",
+            cancelButtonText: "Cancelar",
+            confirmButtonColor: "#0d6efd",
+          });
+          if (!conf.isConfirmed) return;
+        } else {
+          const ok = confirm(
+            "Há dia(s) sem conferência de saída (" +
+              (datas || "—") +
+              "). Deseja gerar o fechamento mesmo assim?"
+          );
+          if (!ok) return;
+        }
+      }
+    }
 
     if (!state.modoEdicao && !idFech && (state.fechModal.g_total || 0) > 0 && state.ajustesFechamento.length === 0) {
       if (window.Swal) {

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -599,7 +599,9 @@ function augmentEntregadoresFromRows(rows){
     rota_criada: "Inserido na rota",
     rota_recalculada: "Rota recalculada",
     encerrado_sistema: "Encerrado pelo sistema",
-    rota_cancelada: "Rota cancelada"
+    rota_cancelada: "Rota cancelada",
+    entrada_base: "Entrada na base",
+    saida_conferida: "Saída conferida"
   };
 
   function normalizeEventoKey(evento) {
@@ -619,6 +621,8 @@ function augmentEntregadoresFromRows(rows){
     if (raw.indexOf("lido") !== -1 || raw.indexOf("leitura") !== -1) return "lido";
     if (raw.indexOf("coleta") !== -1) return "coleta";
     if (raw.indexOf("reatrib") !== -1) return "reatribuido";
+    if (raw.indexOf("entrada") !== -1) return "entrada_base";
+    if (raw.indexOf("conferid") !== -1) return "saida_conferida";
     return "unknown";
   }
 
@@ -664,6 +668,8 @@ function augmentEntregadoresFromRows(rows){
     "Nova saída confirmada": { category: "confirmation", className: "action-confirmation" },
     "Nova saída confirmada (mesmo motoboy)": { category: "confirmation", className: "action-confirmation" },
     "Nova saída confirmada com mesmo motoboy": { category: "confirmation", className: "action-confirmation" },
+    "Entrada na base": { category: "neutral", className: "action-neutral" },
+    "Saída conferida": { category: "confirmation", className: "action-confirmation" },
     "Sem ação": { category: "neutral", className: "action-neutral" }
   };
 

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -601,7 +601,8 @@ function augmentEntregadoresFromRows(rows){
     encerrado_sistema: "Encerrado pelo sistema",
     rota_cancelada: "Rota cancelada",
     entrada_base: "Entrada na base",
-    saida_conferida: "Saída conferida"
+    saida_conferida: "Saída conferida",
+    saida_reconferida: "Saída reconferida"
   };
 
   function normalizeEventoKey(evento) {
@@ -622,6 +623,7 @@ function augmentEntregadoresFromRows(rows){
     if (raw.indexOf("coleta") !== -1) return "coleta";
     if (raw.indexOf("reatrib") !== -1) return "reatribuido";
     if (raw.indexOf("entrada") !== -1) return "entrada_base";
+    if (raw.indexOf("reconferid") !== -1) return "saida_reconferida";
     if (raw.indexOf("conferid") !== -1) return "saida_conferida";
     return "unknown";
   }
@@ -670,6 +672,7 @@ function augmentEntregadoresFromRows(rows){
     "Nova saída confirmada com mesmo motoboy": { category: "confirmation", className: "action-confirmation" },
     "Entrada na base": { category: "neutral", className: "action-neutral" },
     "Saída conferida": { category: "confirmation", className: "action-confirmation" },
+    "Saída reconferida": { category: "confirmation", className: "action-confirmation" },
     "Sem ação": { category: "neutral", className: "action-neutral" }
   };
 

--- a/Master/src/assets/js/pages/tracking-usuarios.js
+++ b/Master/src/assets/js/pages/tracking-usuarios.js
@@ -147,6 +147,10 @@ function initUsers() {
     if (btnReset) {
         btnReset.addEventListener("click", resetPasswordFromSelection);
     }
+    const btnPermAvulso = document.getElementById("btnPermAvulsoLote");
+    if (btnPermAvulso) {
+        btnPermAvulso.addEventListener("click", aplicarPermissaoAvulsoLote);
+    }
 
     document.getElementById("toggleAtivos").addEventListener("change", applyFilters);
     document.getElementById("search").addEventListener("input", applyFilters);
@@ -530,6 +534,8 @@ function openCreate() {
     document.getElementById("podeLerColeta").checked = false;
     document.getElementById("podeLerSaida").checked = true;
     document.getElementById("podeDigitarCodigoManual").checked = true;
+    const podeAvulsoCreate = document.getElementById("podeLancarAvulso");
+    if (podeAvulsoCreate) podeAvulsoCreate.checked = true;
 
     document.getElementById("groupPassword").classList.remove("d-none");
     document.getElementById("groupPasswordConfirm").classList.remove("d-none");
@@ -589,6 +595,8 @@ async function openEdit(id) {
     document.getElementById("podeLerColeta").checked = !!m.pode_ler_coleta;
     document.getElementById("podeLerSaida").checked = m.pode_ler_saida !== false;
     document.getElementById("podeDigitarCodigoManual").checked = !!m.pode_digitar_codigo_manual;
+    const podeAvulsoEdit = document.getElementById("podeLancarAvulso");
+    if (podeAvulsoEdit) podeAvulsoEdit.checked = m.pode_lancar_avulso !== false;
 
     document.getElementById("groupPassword").classList.add("d-none");
     document.getElementById("groupPasswordConfirm").classList.add("d-none");
@@ -636,6 +644,7 @@ function renderMotoboyDetail(data) {
     assign("d-pode-coleta", m.pode_ler_coleta ? "Sim" : "Não");
     assign("d-pode-saida", m.pode_ler_saida !== false ? "Sim" : "Não");
     assign("d-pode-codigo-manual", m.pode_digitar_codigo_manual ? "Sim" : "Não");
+    assign("d-pode-lancar-avulso", m.pode_lancar_avulso !== false ? "Sim" : "Não");
 
     wrap.classList.remove("d-none");
     document.getElementById("motoboy-empty")?.classList.add("d-none");
@@ -769,6 +778,8 @@ async function saveUser(ev) {
         payload.pode_ler_coleta = document.getElementById("podeLerColeta").checked;
         payload.pode_ler_saida = document.getElementById("podeLerSaida").checked;
         payload.pode_digitar_codigo_manual = document.getElementById("podeDigitarCodigoManual").checked;
+        const podeAvulsoEl = document.getElementById("podeLancarAvulso");
+        if (podeAvulsoEl) payload.pode_lancar_avulso = podeAvulsoEl.checked;
     }
 
     try {
@@ -958,6 +969,71 @@ async function resetPasswordFromSelection() {
             icon: "error",
             title: "Erro inesperado",
             text: err.message || "Falha ao resetar senha.",
+        });
+    }
+}
+
+async function aplicarPermissaoAvulsoLote() {
+    const escolha = await Swal.fire({
+        icon: "question",
+        title: "Lançar avulso — todos os motoboys",
+        html: `
+            <p class="mb-2">Aplica a permissão a <strong>todos os entregadores</strong> desta base.</p>
+            <p class="text-muted small mb-0">Motoboys precisarão entrar novamente no app para o token refletir a mudança.</p>
+        `,
+        showDenyButton: true,
+        showCancelButton: true,
+        confirmButtonText: "Liberar para todos",
+        denyButtonText: "Bloquear para todos",
+        cancelButtonText: "Cancelar",
+    });
+
+    if (!escolha.isConfirmed && !escolha.isDenied) return;
+
+    const liberar = !!escolha.isConfirmed;
+    try {
+        const resp = await fetch(`${API}/motoboys/permissoes-lote`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ pode_lancar_avulso: liberar }),
+        });
+
+        if (!resp.ok) {
+            if (resp.status === 401) {
+                await Swal.fire({
+                    icon: "warning",
+                    title: "Sessão expirada",
+                    text: "Faça login novamente para continuar.",
+                });
+                location.href = "login.html";
+                return;
+            }
+            let mensagem = "Erro ao atualizar permissões.";
+            try {
+                const json = await resp.json();
+                if (json.detail) {
+                    mensagem = typeof json.detail === "string" ? json.detail : JSON.stringify(json.detail);
+                }
+            } catch {}
+            await Swal.fire({ icon: "error", title: "Falha", text: mensagem });
+            return;
+        }
+
+        const data = await resp.json().catch(() => ({}));
+        await Swal.fire({
+            icon: "success",
+            title: liberar ? "Avulso liberado" : "Avulso bloqueado",
+            text: `${data.atualizados ?? 0} entregador(es) atualizado(s).`,
+            timer: 2200,
+            showConfirmButton: false,
+        });
+        loadUsers();
+    } catch (err) {
+        await Swal.fire({
+            icon: "error",
+            title: "Erro inesperado",
+            text: err.message || "Falha ao atualizar permissões.",
         });
     }
 }

--- a/Master/src/tracking-acompanhamento.html
+++ b/Master/src/tracking-acompanhamento.html
@@ -111,6 +111,26 @@
                     </div>
 
                     <div id="view-acompanhamento" class="d-none">
+                    <!-- Card Entradas x Saídas (visível quando entrada obrigatória) -->
+                    <div id="card-entrada-saida" class="card mb-3 d-none">
+                      <div class="card-body">
+                        <div class="row g-2 text-center">
+                          <div class="col-md-4">
+                            <span class="small text-secondary fw-semibold d-block">Entradas do dia</span>
+                            <span class="fs-4 fw-bold" id="kpi-entradas">0</span>
+                          </div>
+                          <div class="col-md-4">
+                            <span class="small text-secondary fw-semibold d-block">Saídas do dia</span>
+                            <span class="fs-4 fw-bold" id="kpi-saidas-entrada">0</span>
+                          </div>
+                          <div class="col-md-4">
+                            <span class="small text-secondary fw-semibold d-block">% saída / entrada</span>
+                            <span class="fs-4 fw-bold text-primary" id="kpi-pct-entrada">—</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
                     <!-- KPIs totalizadores -->
                     <div class="row g-2 mb-3 flex-nowrap">
                       <div class="col flex-fill" style="min-width: 0;">

--- a/Master/src/tracking-entrada-leitura.html
+++ b/Master/src/tracking-entrada-leitura.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    @@include("partials/title-meta.html", {"title": "TrackSaídas — Registrar Entrada"})
+    @@include("partials/head-css.html")
+  </head>
+
+  <body data-layout="vertical" data-topbar="light" data-sidebar="dark">
+    <div id="layout-wrapper">
+      @@include("partials/topbar.html")
+      @@include("partials/sidebar.html")
+
+      <div class="main-content">
+        <div class="page-content">
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-12">
+                <div class="page-title-box d-sm-flex align-items-center justify-content-between bg-galaxy-transparent">
+                  <h4 class="mb-sm-0">Registrar Entrada</h4>
+                  <div class="d-flex align-items-center gap-2">
+                    <button type="button" id="btnModoMonitor" class="btn btn-outline-primary btn-sm" title="Alternar para tela com contadores em destaque">
+                      <i class="ri-tv-line me-1"></i><span id="btnModoMonitorText">Modo Monitor</span>
+                    </button>
+                    <ol class="breadcrumb m-0">
+                      <li class="breadcrumb-item"><a href="javascript: void(0);">Operação</a></li>
+                      <li class="breadcrumb-item active">Registrar Entrada</li>
+                    </ol>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="card mb-3">
+              <div class="card-body">
+                <div class="row g-3 align-items-end">
+                  <div class="col-md-7">
+                    <label class="form-label">Código (bipe ou digite)</label>
+                    <div class="input-group">
+                      <input id="codigo" class="form-control" placeholder="Ex.: BR... / código marketplace" autofocus>
+                      <button id="btnScan" type="button" class="btn btn-outline-secondary" title="Ler com a câmera">
+                        <i class="ri-camera-line"></i>
+                      </button>
+                    </div>
+                  </div>
+                  <div class="col-md-5 d-flex gap-2">
+                    <button id="btnRegistrar" class="btn btn-success flex-fill">
+                      <i class="ri-scan-line"></i> Registrar
+                    </button>
+                    <button id="btnLancarAvulso" type="button" class="btn btn-outline-primary">
+                      <i class="ri-add-circle-line"></i> Lançar Avulso
+                    </button>
+                  </div>
+                </div>
+                <div id="msgArea" class="mt-3"></div>
+              </div>
+            </div>
+
+            <div id="modo-padrao">
+              <div class="card mb-3">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                  <h5 class="mb-0">Entradas do dia na base</h5>
+                  <small class="text-muted">Todos os operadores</small>
+                </div>
+                <div class="card-body">
+                  <div class="row g-3">
+                    <div class="col-md-3">
+                      <div class="p-3 rounded card-shopee text-center">
+                        <span class="fw-semibold">Shopee</span>
+                        <div class="fs-5 fw-semibold" id="sum-shopee">0</div>
+                      </div>
+                    </div>
+                    <div class="col-md-3">
+                      <div class="p-3 rounded card-ml text-center">
+                        <span class="fw-semibold">Mercado Livre</span>
+                        <div class="fs-5 fw-semibold" id="sum-ml">0</div>
+                      </div>
+                    </div>
+                    <div class="col-md-3">
+                      <div class="p-3 rounded card-avulso text-center">
+                        <span class="fw-semibold">Avulso</span>
+                        <div class="fs-5 fw-semibold" id="sum-avulso">0</div>
+                      </div>
+                    </div>
+                    <div class="col-md-3">
+                      <div class="p-3 rounded card-total text-center">
+                        <span class="fw-semibold">Total</span>
+                        <div class="fs-5 fw-semibold" id="sum-total">0</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="card">
+                <div class="card-header">
+                  <h5 class="mb-0">Última leitura</h5>
+                </div>
+                <div class="card-body">
+                  <div class="d-flex flex-wrap align-items-center gap-3">
+                    <div>
+                      <div class="text-muted small">Código</div>
+                      <div id="ultima-codigo" class="font-monospace fs-5">—</div>
+                    </div>
+                    <div>
+                      <div class="text-muted small">Serviço</div>
+                      <span id="ultima-servico" class="badge bg-secondary">—</span>
+                    </div>
+                    <div>
+                      <div class="text-muted small">Horário</div>
+                      <div id="ultima-hora" class="fw-semibold">—</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div id="modo-monitor" class="d-none">
+              <div class="d-flex flex-column align-items-center modo-monitor-inner py-4 px-2">
+                <div class="text-center">
+                  <p class="text-muted text-uppercase modo-monitor-section-label mb-2">Total de entradas do dia</p>
+                  <p id="monitor-total" class="modo-monitor-total-num text-primary mb-0">0</p>
+                </div>
+                <div class="row g-3 g-md-4 w-100 justify-content-center" style="max-width: 1000px;">
+                  <div class="col-4">
+                    <div class="card card-shopee border-0 shadow-sm text-center py-4 modo-monitor-card">
+                      <span class="modo-monitor-card-label text-uppercase d-block">Shopee</span>
+                      <div id="monitor-shopee" class="modo-monitor-card-num mt-1">0</div>
+                    </div>
+                  </div>
+                  <div class="col-4">
+                    <div class="card card-ml border-0 shadow-sm text-center py-4 modo-monitor-card">
+                      <span class="modo-monitor-card-label text-uppercase d-block">Mercado Livre</span>
+                      <div id="monitor-ml" class="modo-monitor-card-num mt-1">0</div>
+                    </div>
+                  </div>
+                  <div class="col-4">
+                    <div class="card card-avulso border-0 shadow-sm text-center py-4 modo-monitor-card">
+                      <span class="modo-monitor-card-label text-uppercase d-block">Avulso</span>
+                      <div id="monitor-avulso" class="modo-monitor-card-num mt-1">0</div>
+                    </div>
+                  </div>
+                </div>
+                <div class="text-center mt-4">
+                  <p class="text-muted text-uppercase modo-monitor-section-label mb-1">Última leitura</p>
+                  <p id="monitor-ultima-codigo" class="font-monospace modo-monitor-ultima-codigo mb-1">—</p>
+                  <span id="monitor-ultima-servico" class="badge bg-secondary modo-monitor-ultima-servico">—</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        @@include("partials/footer.html")
+      </div>
+    </div>
+
+    @@include("partials/scan-overlay.html")
+    @@include("partials/customizer.html")
+    @@include("partials/vendor-scripts.html")
+
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.all.min.js"></script>
+    <script>
+      window.TRACK_API_URL = "https://track-saidas-api.onrender.com/api";
+    </script>
+    <script src="assets/js/pages/tracking-entrada-leitura.init.js"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
+</html>

--- a/Master/src/tracking-entregadores-resumo.html
+++ b/Master/src/tracking-entregadores-resumo.html
@@ -205,6 +205,23 @@
               <span id="fech-g-resumo">Pacotes G: Shopee 0, ML 0, Avulso 0 · Total G: 0</span>
             </div>
 
+            <div class="mb-3 d-none" id="fech-conferencia-box">
+              <label class="form-label form-label-modal fw-semibold">Conferência de saída (período)</label>
+              <div class="table-responsive border rounded">
+                <table class="table table-sm mb-0">
+                  <thead class="table-light">
+                    <tr>
+                      <th>Dia</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody id="fech-conferencia-tbody">
+                    <tr><td colspan="2" class="text-muted small">Sem dias com conferência no período.</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
             <div class="mb-3">
               <label class="form-label form-label-modal fw-semibold">Ajustes Manuais</label>
               <div id="fech-lista-ajustes" class="mb-2"></div>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -190,6 +190,14 @@
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-desatribuido" value="desatribuido">
                                   <label class="form-check-label small" for="flt-acao-desatribuido">Desatribuiu pedido</label>
                                 </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-entrada-base" value="entrada_base">
+                                  <label class="form-check-label small" for="flt-acao-entrada-base">Entrada na base</label>
+                                </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-saida-conferida" value="saida_conferida">
+                                  <label class="form-check-label small" for="flt-acao-saida-conferida">Saída conferida</label>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -198,6 +198,10 @@
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-saida-conferida" value="saida_conferida">
                                   <label class="form-check-label small" for="flt-acao-saida-conferida">Saída conferida</label>
                                 </div>
+                                <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-acao-saida-reconferida" value="saida_reconferida">
+                                  <label class="form-check-label small" for="flt-acao-saida-reconferida">Saída reconferida</label>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/Master/src/tracking-usuarios.html
+++ b/Master/src/tracking-usuarios.html
@@ -39,6 +39,10 @@
                             <button class="btn btn-soft-danger" id="btnHeaderDel" disabled>
                                 <i class="ri-delete-bin-line align-bottom me-1"></i> Excluir
                             </button>
+
+                            <button class="btn btn-soft-secondary" id="btnPermAvulsoLote" title="Aplicar permissão de lançar avulso a todos os motoboys da base">
+                                <i class="ri-group-line align-bottom me-1"></i> Avulso (todos)
+                            </button>
                         </div>
 
                         <!-- Filtros direita -->
@@ -184,6 +188,10 @@
                             <div class="col-md-6">
                                 <label class="form-label text-primary fw-medium mb-1">Pode digitar código manual</label>
                                 <div id="d-pode-codigo-manual">—</div>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label text-primary fw-medium mb-1">Pode lançar avulso</label>
+                                <div id="d-pode-lancar-avulso">—</div>
                             </div>
                         </div>
                     </div>
@@ -397,6 +405,15 @@
                                     <input class="form-check-input" type="checkbox" id="podeDigitarCodigoManual" checked>
                                     <label class="form-check-label" for="podeDigitarCodigoManual">Pode digitar código manualmente</label>
                                     <div class="form-text">Ativo por padrão. Desmarque só se precisar bloquear este entregador.</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <div class="mb-3">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="podeLancarAvulso" checked>
+                                    <label class="form-check-label" for="podeLancarAvulso">Pode lançar avulso</label>
+                                    <div class="form-text">Ativo por padrão. Desmarque para bloquear o lançamento de avulso no app deste entregador.</div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Resumo

Suporte web à entrada obrigatória e conferência de saída: tela Registrar Entrada, toggles/alerta no fechamento, permissão de avulso em Usuários e card entradas×saídas no acompanhamento.

## Tipo de alteração

- [x] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Tela `tracking-entrada-leitura` (totais do dia, monitor, avulso, scan sequencial)
- Menu **Registrar Entrada** só com flag do owner
- Usuários: checkbox `pode_lancar_avulso` + bulk “Avulso (todos)”
- Acompanhamento: card Entradas / Saídas / %
- Labels/filtros de entrada, conferência e saída reconferida em Registros
- Toggles e alerta soft de conferência no fechamento

## Como testar

- Dependência: backend desta mesma branch deployado + migrations
- Com entrada on: menu → Registrar Entrada → bipar vários códigos em sequência
- Usuários: editar motoboy e bulk de avulso
- Acompanhamento: card entradas×saídas visível com flag on

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [x] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Rollback

- Reverter merge desta branch; UI some do menu quando a flag do owner estiver off.

Made with [Cursor](https://cursor.com)