### PR TITLE
feat: tela web de avisos da base

### DIFF
--- a/Master/src/assets/js/pages/tracking-avisos.init.js
+++ b/Master/src/assets/js/pages/tracking-avisos.init.js
@@ -1,0 +1,145 @@
+/* Avisos da base — envio e histórico (admin) */
+(function () {
+  "use strict";
+
+  const API_URL = (window.TRACK_API_URL || "").replace(/\/+$/, "");
+  const qs = (sel) => document.querySelector(sel);
+
+  async function api(path, opts = {}) {
+    const res = await fetch(`${API_URL}${path}`, {
+      credentials: "include",
+      headers: { "Content-Type": "application/json", ...(opts.headers || {}) },
+      ...opts,
+    });
+    if (res.status === 401) {
+      window.location.href = "auth-signin-tracking-v2.html";
+      throw new Error("Não autenticado");
+    }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const detail = data.detail || data.message || `HTTP ${res.status}`;
+      throw new Error(typeof detail === "string" ? detail : JSON.stringify(detail));
+    }
+    return data;
+  }
+
+  function fmtWhen(iso) {
+    if (!iso) return "—";
+    try {
+      const d = new Date(iso);
+      return d.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+    } catch {
+      return iso;
+    }
+  }
+
+  async function loadMotoboys() {
+    const sel = qs("#aviso-motoboys");
+    if (!sel) return;
+    try {
+      const rows = await api("/users/motoboys");
+      sel.innerHTML = (rows || [])
+        .map((m) => `<option value="${m.id_motoboy}">${m.nome || "Motoboy " + m.id_motoboy}</option>`)
+        .join("");
+    } catch (e) {
+      sel.innerHTML = "";
+      console.warn("avisos: falha motoboys", e);
+    }
+  }
+
+  async function loadHistorico() {
+    const tbody = qs("#avisos-tbody");
+    if (!tbody) return;
+    tbody.innerHTML = `<tr><td colspan="4" class="text-muted text-center py-4">Carregando…</td></tr>`;
+    try {
+      const rows = await api("/avisos?limit=40");
+      if (!rows.length) {
+        tbody.innerHTML = `<tr><td colspan="4" class="text-muted text-center py-4">Nenhum aviso enviado ainda.</td></tr>`;
+        return;
+      }
+      tbody.innerHTML = rows
+        .map((a) => {
+          const urg = (a.prioridade || "") === "urgente";
+          return `<tr>
+            <td class="text-nowrap">${fmtWhen(a.criado_em)}</td>
+            <td>${(a.titulo || "").replace(/</g, "&lt;")}</td>
+            <td>${urg ? '<span class="badge bg-danger">Urgente</span>' : '<span class="badge bg-secondary">Normal</span>'}</td>
+            <td>${a.destinatarios_count ?? 0}</td>
+          </tr>`;
+        })
+        .join("");
+    } catch (e) {
+      tbody.innerHTML = `<tr><td colspan="4" class="text-danger text-center py-4">${e.message}</td></tr>`;
+    }
+  }
+
+  function syncTodosUi() {
+    const todos = qs("#aviso-todos")?.checked;
+    const wrap = qs("#wrap-motoboys");
+    if (wrap) wrap.style.display = todos ? "none" : "";
+  }
+
+  async function enviar() {
+    const titulo = (qs("#aviso-titulo")?.value || "").trim();
+    const mensagem = (qs("#aviso-mensagem")?.value || "").trim();
+    const urgente = !!qs("#aviso-urgente")?.checked;
+    const todos = !!qs("#aviso-todos")?.checked;
+    const sel = qs("#aviso-motoboys");
+    const ids = sel
+      ? Array.from(sel.selectedOptions).map((o) => Number(o.value)).filter((n) => Number.isFinite(n))
+      : [];
+
+    if (!titulo || !mensagem) {
+      if (window.Swal) Swal.fire({ icon: "warning", title: "Preencha título e mensagem" });
+      else alert("Preencha título e mensagem");
+      return;
+    }
+    if (!todos && !ids.length) {
+      if (window.Swal) Swal.fire({ icon: "warning", title: "Selecione motoboys ou marque todos" });
+      else alert("Selecione motoboys ou marque todos");
+      return;
+    }
+
+    const btn = qs("#btn-enviar-aviso");
+    if (btn) btn.disabled = true;
+    try {
+      const res = await api("/avisos", {
+        method: "POST",
+        body: JSON.stringify({
+          titulo,
+          mensagem,
+          prioridade: urgente ? "urgente" : "normal",
+          todos_ativos: todos,
+          motoboy_ids: todos ? null : ids,
+        }),
+      });
+      if (window.Swal) {
+        await Swal.fire({
+          icon: "success",
+          title: "Aviso enviado",
+          text: `Enviado para ${res.destinatarios_count} motoboy(s).`,
+        });
+      } else {
+        alert(`Enviado para ${res.destinatarios_count} motoboy(s).`);
+      }
+      qs("#aviso-titulo").value = "";
+      qs("#aviso-mensagem").value = "";
+      qs("#aviso-urgente").checked = false;
+      await loadHistorico();
+    } catch (e) {
+      if (window.Swal) Swal.fire({ icon: "error", title: "Erro", text: e.message });
+      else alert(e.message);
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    qs("#aviso-todos")?.addEventListener("change", syncTodosUi);
+    qs("#btn-enviar-aviso")?.addEventListener("click", () => void enviar());
+    qs("#btn-atualizar-avisos")?.addEventListener("click", () => void loadHistorico());
+    syncTodosUi();
+    void loadMotoboys();
+    void loadHistorico();
+  });
+})();

--- a/Master/src/tracking-avisos.html
+++ b/Master/src/tracking-avisos.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    @@include("partials/title-meta.html", {"title": "TrackSaídas — Avisos da Base"})
+    @@include("partials/head-css.html")
+  </head>
+  <body data-layout="vertical" data-topbar="light" data-sidebar="dark">
+    <div id="layout-wrapper">
+      @@include("partials/menu.html")
+
+      <div class="main-content">
+        <div class="page-content">
+          <div class="container-fluid">
+            @@include("partials/page-title.html", {"pagetitle": "Operação", "title": "Avisos da Base", "withSubtitle": true, "ownerTerm": ""})
+
+            <div class="row">
+              <div class="col-lg-5">
+                <div class="card">
+                  <div class="card-header">
+                    <h5 class="card-title mb-0">Novo aviso</h5>
+                  </div>
+                  <div class="card-body">
+                    <div class="mb-3">
+                      <label class="form-label">Título</label>
+                      <input type="text" id="aviso-titulo" class="form-control" maxlength="120" placeholder="Ex.: Atenção à base" />
+                    </div>
+                    <div class="mb-3">
+                      <label class="form-label">Mensagem</label>
+                      <textarea id="aviso-mensagem" class="form-control" rows="4" maxlength="500" placeholder="Escreva o aviso..."></textarea>
+                    </div>
+                    <div class="form-check form-switch mb-2">
+                      <input class="form-check-input" type="checkbox" id="aviso-urgente" />
+                      <label class="form-check-label" for="aviso-urgente">Urgente (motoboy é obrigado a abrir no app)</label>
+                    </div>
+                    <div class="form-check form-switch mb-3">
+                      <input class="form-check-input" type="checkbox" id="aviso-todos" />
+                      <label class="form-check-label" for="aviso-todos">Todos os motoboys ativos</label>
+                    </div>
+                    <div id="wrap-motoboys" class="mb-3">
+                      <label class="form-label">Motoboys</label>
+                      <select id="aviso-motoboys" class="form-select" multiple size="8"></select>
+                      <div class="form-text">Segure Ctrl/Cmd para selecionar vários.</div>
+                    </div>
+                    <button type="button" id="btn-enviar-aviso" class="btn btn-primary w-100">
+                      <i class="ri-send-plane-line me-1"></i> Enviar aviso
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="col-lg-7">
+                <div class="card">
+                  <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="card-title mb-0">Histórico recente</h5>
+                    <button type="button" id="btn-atualizar-avisos" class="btn btn-sm btn-soft-primary">Atualizar</button>
+                  </div>
+                  <div class="card-body">
+                    <div class="table-responsive">
+                      <table class="table table-sm align-middle mb-0">
+                        <thead>
+                          <tr>
+                            <th>Quando</th>
+                            <th>Título</th>
+                            <th>Prioridade</th>
+                            <th>Destinatários</th>
+                          </tr>
+                        </thead>
+                        <tbody id="avisos-tbody">
+                          <tr><td colspan="4" class="text-muted text-center py-4">Carregando…</td></tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        @@include("partials/footer.html")
+      </div>
+    </div>
+    @@include("partials/vendor-scripts.html")
+    <script src="assets/js/app.js"></script>
+    <script src="assets/js/pages/tracking-avisos.init.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Resumo

Adiciona a tela web “Avisos da Base” para envio de avisos normais/urgentes aos motoboys via API.

**Atenção:** esta branch também carrega commits anteriores ainda não mergeados em `main` (entrada web, conferência, privacidade e ajustes de landing).

## Tipo de alteração

- [x] feature
- [ ] bug
- [ ] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Página `tracking-avisos.html` + `tracking-avisos.init.js`
- Integração com endpoints de avisos do backend

## Como testar

- Abrir menu “Avisos da Base” com backend da branch correspondente
- Enviar aviso normal e urgente para um motoboy
- Confirmar recebimento no app mobile

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Dependências

- Backend: `track_saidas` (`feat/mobile-notificacoes-alta`) — https://github.com/TrackingSaida/track_saidas/pull/38
- Mobile: `track_saida_mobile` (`feat/mobile-notificacoes-alta`)

## Rollback

- Reverter merge; menu/tela de avisos deixa de existir na web.

Made with [Cursor](https://cursor.com)