### PR TITLE
feat: galeria lightbox, obriga foto no avulso e thumbs no histórico

### DIFF
--- a/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
@@ -257,13 +257,15 @@
     }
   };
 
-  window.TrackAPI.lancarAvulso = async function ({ identificacao, quantidade, motoboy_id, entregador_id, entregador }) {
+  window.TrackAPI.lancarAvulso = async function ({ identificacao, quantidade, motoboy_id, entregador_id, entregador, foto_object_key, photo_id }) {
     try {
       const body = { quantidade };
       if (identificacao != null) body.identificacao = identificacao;
       if (motoboy_id != null) body.motoboy_id = motoboy_id;
       if (entregador_id != null) body.entregador_id = entregador_id;
       if (entregador != null) body.entregador = entregador;
+      if (foto_object_key) body.foto_object_key = foto_object_key;
+      if (photo_id) body.photo_id = photo_id;
       const res = await req("/pedidos/lancar-avulso", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/Master/src/assets/js/pages/tracking-leitura.init.js
+++ b/Master/src/assets/js/pages/tracking-leitura.init.js
@@ -631,10 +631,54 @@ function createRow(row){
       ? TrackAPI.registerSaida({ entregador_id, entregador, codigo, servico })
       : Promise.reject(new Error("TrackAPI.registerSaida não disponível"));
   }
-  function apiLancarAvulso({ motoboy_id, entregador, identificacao, quantidade }){
+  function apiLancarAvulso({ motoboy_id, entregador, identificacao, quantidade, foto_object_key, photo_id }){
     return window.TrackAPI?.lancarAvulso
-      ? TrackAPI.lancarAvulso({ motoboy_id, entregador, identificacao, quantidade })
+      ? TrackAPI.lancarAvulso({ motoboy_id, entregador, identificacao, quantidade, foto_object_key, photo_id })
       : Promise.reject(new Error("TrackAPI.lancarAvulso não disponível"));
+  }
+
+  function getApiBaseUrl() {
+    let base = (window.TRACK_API_URL || "").replace(/\/+$/, "");
+    if (!base.endsWith("/api")) base += "/api";
+    return base;
+  }
+
+  function newPhotoId() {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+    return "web-" + Date.now() + "-" + Math.random().toString(36).slice(2, 10);
+  }
+
+  async function uploadAvulsoPhoto(file) {
+    const photoId = newPhotoId();
+    const contentType = (file && file.type) ? file.type : "image/jpeg";
+    const filename = (file && file.name) ? file.name : "avulso.jpg";
+    const presignRes = await fetch(getApiBaseUrl() + "/upload/presign", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({
+        filename,
+        tipo: "lancar_avulso",
+        content_type: contentType,
+        photo_id: photoId,
+      }),
+    });
+    let presignData = null;
+    try { presignData = await presignRes.json(); } catch (_) {}
+    if (!presignRes.ok) {
+      const msg = (presignData && presignData.detail) || "Erro ao preparar upload da foto.";
+      throw new Error(typeof msg === "string" ? msg : "Erro ao preparar upload da foto.");
+    }
+    const uploadUrl = presignData.upload_url;
+    const objectKey = presignData.object_key;
+    const headers = Object.assign({ "Content-Type": contentType }, presignData.headers || {});
+    const putRes = await fetch(uploadUrl, { method: "PUT", headers, body: file });
+    if (!putRes.ok) {
+      throw new Error("Falha ao enviar foto (" + putRes.status + ").");
+    }
+    return { foto_object_key: objectKey, photo_id: photoId };
   }
 
   function parseApiDetailError(res, fallback) {
@@ -770,18 +814,23 @@ function createRow(row){
   }
 
   // ---------- carregar motoboys (users role=4) ----------
-  // Cache id_motoboy -> nome para lookups
+  // Cache id_motoboy -> nome para lookups; meta inclui avulso_exige_foto quando a API retornar.
   let entregadoresMap = new Map(); // id_motoboy -> nome (mantido para compat.)
+  let motoboysMetaMap = new Map(); // id_motoboy -> { avulso_exige_foto }
   function loadMotoboys(){
     return apiGetMotoboys().then(res => {
       const raw = Array.isArray(res) ? res : (res?.data ?? []);
       entregadoresMap = new Map();
+      motoboysMetaMap = new Map();
       const opts = raw
         .filter(e => e && (e.id_motoboy != null || e.id != null))
         .map(e => {
           const id = e.id_motoboy ?? e.id;
           const nome = (e?.nome || e?.name || String(id)).trim() || String(id);
           entregadoresMap.set(String(id), nome);
+          motoboysMetaMap.set(String(id), {
+            avulso_exige_foto: !!e.avulso_exige_foto,
+          });
           return { id, nome };
         })
         .sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"))
@@ -1501,6 +1550,14 @@ btnLancarAvulso?.addEventListener("click", async (e) => {
   }
   const motoboyId = parseInt(motoboyIdRaw, 10);
   const entregador = selEnt?.options[selEnt.selectedIndex]?.text?.trim() || entregadoresMap.get(motoboyIdRaw) || "";
+  const exigeFoto = !!(motoboysMetaMap.get(motoboyIdRaw)?.avulso_exige_foto);
+  const fotoFieldHtml = exigeFoto
+    ? `
+        <label class="form-label mb-1" for="avulso-foto">Foto do lote <span class="text-danger">*</span></label>
+        <input id="avulso-foto" type="file" accept="image/*" capture="environment" class="form-control mb-1" />
+        <div class="form-text mb-3">Este entregador exige foto ao lançar avulso.</div>
+      `
+    : "";
   const modal = await Swal.fire({
     title: "Lançar Avulso",
     html: `
@@ -1510,7 +1567,8 @@ btnLancarAvulso?.addEventListener("click", async (e) => {
         <div class="form-text mb-3">Opcional. Até 32 caracteres para identificar o lote na operação.</div>
         <label class="form-label mb-1" for="avulso-quantidade">Quantidade</label>
         <input id="avulso-quantidade" type="number" min="1" max="50" step="1" class="form-control mb-1" value="1" />
-        <div class="form-text">Informe entre 1 e 50 pacotes por lançamento.</div>
+        <div class="form-text ${exigeFoto ? "mb-3" : ""}">Informe entre 1 e 50 pacotes por lançamento.</div>
+        ${fotoFieldHtml}
       </div>
     `,
     showCancelButton: true,
@@ -1520,9 +1578,11 @@ btnLancarAvulso?.addEventListener("click", async (e) => {
     preConfirm: () => {
       const identificacaoEl = document.getElementById("avulso-identificacao");
       const quantidadeEl = document.getElementById("avulso-quantidade");
+      const fotoEl = document.getElementById("avulso-foto");
       const identificacaoVal = identificacaoEl ? String(identificacaoEl.value || "").trim().slice(0, 32) : "";
       const quantidadeRaw = quantidadeEl ? String(quantidadeEl.value || "").trim() : "1";
       const quantidadeVal = parseInt(quantidadeRaw, 10);
+      const fotoFile = fotoEl && fotoEl.files && fotoEl.files[0] ? fotoEl.files[0] : null;
       if (identificacaoVal.length > 32) {
         Swal.showValidationMessage("Identificação deve ter no máximo 32 caracteres.");
         return null;
@@ -1535,12 +1595,17 @@ btnLancarAvulso?.addEventListener("click", async (e) => {
         Swal.showValidationMessage("Quantidade máxima é 50.");
         return null;
       }
-      return { identificacao: identificacaoVal, quantidade: quantidadeVal };
+      if (exigeFoto && !fotoFile) {
+        Swal.showValidationMessage("Foto obrigatória para este entregador.");
+        return null;
+      }
+      return { identificacao: identificacaoVal, quantidade: quantidadeVal, fotoFile };
     },
   });
   if (!modal.isConfirmed || !modal.value) return;
   const identificacao = modal.value.identificacao || "";
   const quantidade = modal.value.quantidade;
+  const fotoFile = modal.value.fotoFile || null;
   if (identificacao.length > 32) {
     showMsgIcon("erro", "Identificação deve ter no máximo 32 caracteres.");
     Sound.play("err");
@@ -1551,11 +1616,28 @@ btnLancarAvulso?.addEventListener("click", async (e) => {
     Sound.play("err");
     return;
   }
+  if (exigeFoto && !fotoFile) {
+    showMsgIcon("erro", "Foto obrigatória para este entregador.");
+    Sound.play("err");
+    return;
+  }
+  let fotoPayload = {};
+  if (fotoFile) {
+    try {
+      fotoPayload = await uploadAvulsoPhoto(fotoFile);
+    } catch (uploadErr) {
+      showMsgIcon("erro", uploadErr?.message || "Erro ao enviar foto.");
+      Sound.play("err");
+      return;
+    }
+  }
   const res = await apiLancarAvulso({
     motoboy_id: motoboyId,
     entregador,
     identificacao: identificacao.trim() || null,
     quantidade,
+    foto_object_key: fotoPayload.foto_object_key,
+    photo_id: fotoPayload.photo_id,
   });
   if (!res?.ok) {
     showMsgIcon("erro", parseApiDetailError(res, "Erro ao lançar avulso."));

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1112,6 +1112,18 @@ function setupPagerEvents() {
     return photos;
   }
 
+  /** Lista plana ordenada por globalIndex para galeria do lightbox. */
+  function flattenAllPhotos(photoGroups) {
+    var photos = [];
+    Object.keys(photoGroups || {}).forEach(function(k) {
+      (photoGroups[k] || []).forEach(function(p) { photos.push(p); });
+    });
+    photos.sort(function(a, b) {
+      return (Number(a.globalIndex) || 0) - (Number(b.globalIndex) || 0);
+    });
+    return photos;
+  }
+
   function resolveEventIndexForPhoto(historico, eventIndexes, photo) {
     if (!eventIndexes.length) return -1;
     var photoTs = photo && photo.createdAt ? Date.parse(photo.createdAt) : NaN;
@@ -1155,14 +1167,31 @@ function setupPagerEvents() {
     return map;
   }
 
+  function isEventoLancarAvulso(ev) {
+    return String(ev || "").toLowerCase().replace(/\s+/g, "_") === "lancar_avulso";
+  }
+
   function buildEventPhotoMaps(historico, groups) {
     var ausenciaMap = mapPhotosToEventIndexes(historico, groups, "ausente");
     var entregaMap = mapPhotosToEventIndexes(historico, groups, "entregue");
+    var avulsoMap = {};
+    var avulsoIndexes = [];
+    historico.forEach(function(item, i) {
+      if (isEventoLancarAvulso(item.evento)) avulsoIndexes.push(i);
+    });
+    flattenPhotoGroups(groups, "lancar_avulso").forEach(function(photo) {
+      var target = resolveEventIndexForPhoto(historico, avulsoIndexes, photo);
+      if (target < 0 && avulsoIndexes.length) target = avulsoIndexes[avulsoIndexes.length - 1];
+      if (target < 0) return;
+      if (!avulsoMap[target]) avulsoMap[target] = [];
+      avulsoMap[target].push(photo);
+    });
     var legacy = groups[grupoFotoKey("legacy", 1)] || [];
     if (legacy.length) {
       legacy.forEach(function(photo) {
         var lastEntrega = findLastHistoricoIndexByKeys(historico, isEventoEntrega);
         var lastAusencia = findLastHistoricoIndexByKeys(historico, isEventoAusencia);
+        var lastAvulso = findLastHistoricoIndexByKeys(historico, isEventoLancarAvulso);
         var absIndexes = [];
         var entIndexes = [];
         historico.forEach(function(item, i) {
@@ -1174,7 +1203,7 @@ function setupPagerEvents() {
           var all = absIndexes.concat(entIndexes).sort(function(a, b) { return a - b; });
           target = resolveEventIndexForPhoto(historico, all, photo);
         } else {
-          target = lastEntrega >= 0 ? lastEntrega : lastAusencia;
+          target = lastEntrega >= 0 ? lastEntrega : (lastAusencia >= 0 ? lastAusencia : lastAvulso);
         }
         if (target < 0) return;
         if (isEventoEntrega(historico[target].evento)) {
@@ -1183,10 +1212,13 @@ function setupPagerEvents() {
         } else if (isEventoAusencia(historico[target].evento)) {
           if (!ausenciaMap[target]) ausenciaMap[target] = [];
           ausenciaMap[target].push(photo);
+        } else if (isEventoLancarAvulso(historico[target].evento)) {
+          if (!avulsoMap[target]) avulsoMap[target] = [];
+          avulsoMap[target].push(photo);
         }
       });
     }
-    return { ausenciaMap: ausenciaMap, entregaMap: entregaMap };
+    return { ausenciaMap: ausenciaMap, entregaMap: entregaMap, avulsoMap: avulsoMap };
   }
 
   /** Índice global da 1ª foto do último evento com comprovante (para export/share). */
@@ -1227,6 +1259,7 @@ function setupPagerEvents() {
       var eventPhotos = [];
       if (isEventoAusencia(item.evento)) eventPhotos = maps.ausenciaMap[index] || [];
       else if (isEventoEntrega(item.evento)) eventPhotos = maps.entregaMap[index] || [];
+      else if (isEventoLancarAvulso(item.evento)) eventPhotos = maps.avulsoMap[index] || [];
 
       var extrasHtml = "";
       if (isEventoAusencia(item.evento)) {
@@ -1248,8 +1281,8 @@ function setupPagerEvents() {
       if (eventPhotos.length) {
         thumbHtml = "<div class=\"timeline-thumbs d-flex flex-wrap gap-2 mt-2\">" +
           eventPhotos.map(function(photo, photoIndex) {
-            return "<button type=\"button\" class=\"timeline-thumb-btn border-0 p-0 bg-transparent\" data-photo-url=\"" +
-              escapeHtml(photo.url) +
+            return "<button type=\"button\" class=\"timeline-thumb-btn border-0 p-0 bg-transparent\" data-photo-index=\"" +
+              String(photo.globalIndex != null ? photo.globalIndex : photoIndex) +
               "\" title=\"Ampliar comprovante\">" +
               "<img src=\"" + escapeHtml(photo.url) + "\" alt=\"Comprovante " + (photoIndex + 1) +
               "\" class=\"rounded border timeline-thumb-img\" />" +
@@ -1473,6 +1506,7 @@ function setupPagerEvents() {
       }
 
       var photoGroups = buildPhotoGroups(fotosTipadas, urlsByKey, fotoUrls);
+      var galleryPhotos = flattenAllPhotos(photoGroups);
       var exportIndex = indexExportUltimoEvento(historico, photoGroups);
       var hasPhotos = Object.keys(photoGroups).some(function(k) { return photoGroups[k] && photoGroups[k].length; });
 
@@ -1526,6 +1560,9 @@ function setupPagerEvents() {
         '</div>' +
         '<div id="reg-photo-lightbox" class="reg-photo-lightbox d-none" role="dialog" aria-modal="true">' +
           '<button type="button" class="reg-photo-lightbox-close" aria-label="Fechar">&times;</button>' +
+          '<button type="button" class="reg-photo-lightbox-nav reg-photo-lightbox-prev" aria-label="Anterior">&lsaquo;</button>' +
+          '<button type="button" class="reg-photo-lightbox-nav reg-photo-lightbox-next" aria-label="Próxima">&rsaquo;</button>' +
+          '<span class="reg-photo-lightbox-counter" aria-live="polite"></span>' +
           '<img id="reg-photo-lightbox-img" alt="Comprovante ampliado" />' +
         '</div>';
 
@@ -1565,25 +1602,98 @@ function setupPagerEvents() {
 
       var lightbox = document.getElementById("reg-photo-lightbox");
       var lightboxImg = document.getElementById("reg-photo-lightbox-img");
+      var lightboxCounter = lightbox ? lightbox.querySelector(".reg-photo-lightbox-counter") : null;
+      var lightboxPrev = lightbox ? lightbox.querySelector(".reg-photo-lightbox-prev") : null;
+      var lightboxNext = lightbox ? lightbox.querySelector(".reg-photo-lightbox-next") : null;
+      var galleryIndex = 0;
+      var touchStartX = null;
+
+      function updateLightboxView() {
+        if (!lightboxImg || !galleryPhotos.length) return;
+        galleryIndex = Math.max(0, Math.min(galleryIndex, galleryPhotos.length - 1));
+        lightboxImg.src = galleryPhotos[galleryIndex].url;
+        if (lightboxCounter) {
+          lightboxCounter.textContent = (galleryIndex + 1) + " / " + galleryPhotos.length;
+        }
+        var single = galleryPhotos.length <= 1;
+        if (lightboxPrev) lightboxPrev.classList.toggle("d-none", single);
+        if (lightboxNext) lightboxNext.classList.toggle("d-none", single);
+      }
+
+      function onLightboxKeydown(ev) {
+        if (!lightbox || lightbox.classList.contains("d-none")) return;
+        if (ev.key === "Escape") {
+          ev.preventDefault();
+          closeLightbox();
+        } else if (ev.key === "ArrowLeft") {
+          ev.preventDefault();
+          navLightbox(-1);
+        } else if (ev.key === "ArrowRight") {
+          ev.preventDefault();
+          navLightbox(1);
+        }
+      }
+
+      function navLightbox(delta) {
+        if (!galleryPhotos.length || galleryPhotos.length <= 1) return;
+        galleryIndex = (galleryIndex + delta + galleryPhotos.length) % galleryPhotos.length;
+        updateLightboxView();
+      }
+
+      function openLightboxAt(index) {
+        if (!lightbox || !galleryPhotos.length) return;
+        var idx = Number(index);
+        if (!Number.isFinite(idx) || idx < 0) idx = 0;
+        galleryIndex = idx;
+        updateLightboxView();
+        lightbox.classList.remove("d-none");
+        document.addEventListener("keydown", onLightboxKeydown);
+      }
+
       function closeLightbox() {
         if (!lightbox) return;
         lightbox.classList.add("d-none");
         if (lightboxImg) lightboxImg.removeAttribute("src");
+        document.removeEventListener("keydown", onLightboxKeydown);
+        touchStartX = null;
       }
+
       if (lightbox) {
         var closeBtn = lightbox.querySelector(".reg-photo-lightbox-close");
         if (closeBtn) closeBtn.addEventListener("click", closeLightbox);
+        if (lightboxPrev) {
+          lightboxPrev.addEventListener("click", function(ev) {
+            ev.stopPropagation();
+            navLightbox(-1);
+          });
+        }
+        if (lightboxNext) {
+          lightboxNext.addEventListener("click", function(ev) {
+            ev.stopPropagation();
+            navLightbox(1);
+          });
+        }
         lightbox.addEventListener("click", function(ev) {
           if (ev.target === lightbox) closeLightbox();
         });
+        lightbox.addEventListener("touchstart", function(ev) {
+          if (!ev.touches || !ev.touches.length) return;
+          touchStartX = ev.touches[0].clientX;
+        }, { passive: true });
+        lightbox.addEventListener("touchend", function(ev) {
+          if (touchStartX == null || !ev.changedTouches || !ev.changedTouches.length) return;
+          var deltaX = ev.changedTouches[0].clientX - touchStartX;
+          touchStartX = null;
+          if (Math.abs(deltaX) < 40) return;
+          navLightbox(deltaX > 0 ? -1 : 1);
+        }, { passive: true });
       }
       if (detailContent) {
         detailContent.querySelectorAll(".timeline-thumb-btn").forEach(function(btn) {
           btn.addEventListener("click", function() {
-            var url = btn.getAttribute("data-photo-url");
-            if (!url || !lightbox || !lightboxImg) return;
-            lightboxImg.src = url;
-            lightbox.classList.remove("d-none");
+            var idx = parseInt(btn.getAttribute("data-photo-index"), 10);
+            if (!Number.isFinite(idx)) idx = 0;
+            openLightboxAt(idx);
           });
         });
       }

--- a/Master/src/assets/js/pages/tracking-usuarios.js
+++ b/Master/src/assets/js/pages/tracking-usuarios.js
@@ -178,6 +178,10 @@ function initUsers() {
 
     document.getElementById("formUser").addEventListener("submit", saveUser);
     document.getElementById("role").addEventListener("change", toggleMotoboySection);
+    const podeAvulsoToggle = document.getElementById("podeLancarAvulso");
+    if (podeAvulsoToggle) {
+        podeAvulsoToggle.addEventListener("change", toggleAvulsoExigeFotoVisibility);
+    }
 
     document.getElementById("contato").addEventListener("input", (ev) => {
         ev.target.value = maskCellphone(ev.target.value);
@@ -257,11 +261,22 @@ function toggleMotoboySection() {
         colMotoboy.classList.remove("d-none");
         document.getElementById("podeLerColeta").disabled = ignorarColeta;
         if (ignorarColeta) document.getElementById("podeLerColeta").checked = false;
+        toggleAvulsoExigeFotoVisibility();
     } else {
         colUser.classList.remove("col-6");
         colUser.classList.add("col-12");
         colMotoboy.classList.add("d-none");
     }
+}
+
+function toggleAvulsoExigeFotoVisibility() {
+    const podeAvulsoEl = document.getElementById("podeLancarAvulso");
+    const wrap = document.getElementById("avulsoExigeFotoWrap");
+    const exigeEl = document.getElementById("avulsoExigeFoto");
+    if (!wrap || !podeAvulsoEl) return;
+    const show = !!podeAvulsoEl.checked;
+    wrap.classList.toggle("d-none", !show);
+    if (!show && exigeEl) exigeEl.checked = false;
 }
 
 
@@ -536,6 +551,8 @@ function openCreate() {
     document.getElementById("podeDigitarCodigoManual").checked = true;
     const podeAvulsoCreate = document.getElementById("podeLancarAvulso");
     if (podeAvulsoCreate) podeAvulsoCreate.checked = true;
+    const avulsoExigeCreate = document.getElementById("avulsoExigeFoto");
+    if (avulsoExigeCreate) avulsoExigeCreate.checked = false;
 
     document.getElementById("groupPassword").classList.remove("d-none");
     document.getElementById("groupPasswordConfirm").classList.remove("d-none");
@@ -597,6 +614,10 @@ async function openEdit(id) {
     document.getElementById("podeDigitarCodigoManual").checked = !!m.pode_digitar_codigo_manual;
     const podeAvulsoEdit = document.getElementById("podeLancarAvulso");
     if (podeAvulsoEdit) podeAvulsoEdit.checked = m.pode_lancar_avulso !== false;
+    const avulsoExigeEdit = document.getElementById("avulsoExigeFoto");
+    if (avulsoExigeEdit) {
+        avulsoExigeEdit.checked = !!(m.pode_lancar_avulso !== false && m.avulso_exige_foto);
+    }
 
     document.getElementById("groupPassword").classList.add("d-none");
     document.getElementById("groupPasswordConfirm").classList.add("d-none");
@@ -645,6 +666,7 @@ function renderMotoboyDetail(data) {
     assign("d-pode-saida", m.pode_ler_saida !== false ? "Sim" : "Não");
     assign("d-pode-codigo-manual", m.pode_digitar_codigo_manual ? "Sim" : "Não");
     assign("d-pode-lancar-avulso", m.pode_lancar_avulso !== false ? "Sim" : "Não");
+    assign("d-avulso-exige-foto", m.avulso_exige_foto ? "Sim" : "Não");
 
     wrap.classList.remove("d-none");
     document.getElementById("motoboy-empty")?.classList.add("d-none");
@@ -779,7 +801,10 @@ async function saveUser(ev) {
         payload.pode_ler_saida = document.getElementById("podeLerSaida").checked;
         payload.pode_digitar_codigo_manual = document.getElementById("podeDigitarCodigoManual").checked;
         const podeAvulsoEl = document.getElementById("podeLancarAvulso");
-        if (podeAvulsoEl) payload.pode_lancar_avulso = podeAvulsoEl.checked;
+        const avulsoExigeEl = document.getElementById("avulsoExigeFoto");
+        const podeLancarAvulso = podeAvulsoEl ? podeAvulsoEl.checked : true;
+        if (podeAvulsoEl) payload.pode_lancar_avulso = podeLancarAvulso;
+        payload.avulso_exige_foto = podeLancarAvulso && avulsoExigeEl ? !!avulsoExigeEl.checked : false;
     }
 
     try {

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -605,7 +605,8 @@
     position: fixed; inset: 0; z-index: 2100;
     background: rgba(15, 23, 42, 0.82);
     display: flex; align-items: center; justify-content: center;
-    padding: 24px;
+    padding: 24px 56px;
+    touch-action: pan-y pinch-zoom;
   }
   .reg-photo-lightbox.d-none { display: none !important; }
   .reg-photo-lightbox img {
@@ -619,6 +620,24 @@
     position: absolute; top: 16px; right: 20px;
     border: 0; background: transparent; color: #fff;
     font-size: 36px; line-height: 1; cursor: pointer;
+    z-index: 2;
+  }
+  .reg-photo-lightbox-nav {
+    position: absolute; top: 50%; transform: translateY(-50%);
+    border: 0; background: rgba(255, 255, 255, 0.15); color: #fff;
+    width: 44px; height: 44px; border-radius: 50%;
+    font-size: 28px; line-height: 1; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    z-index: 2;
+  }
+  .reg-photo-lightbox-nav:hover { background: rgba(255, 255, 255, 0.28); }
+  .reg-photo-lightbox-prev { left: 16px; }
+  .reg-photo-lightbox-next { right: 16px; }
+  .reg-photo-lightbox-counter {
+    position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%);
+    color: #fff; font-size: 14px; font-weight: 600;
+    background: rgba(0, 0, 0, 0.45); padding: 6px 14px; border-radius: 20px;
+    z-index: 2;
   }
   .status-badge { padding: 4px 10px; border-radius: 20px; font-size: 12px; font-weight: 600; }
   .status-success { background: #e6f7ee; color: #28a745; }

--- a/Master/src/tracking-usuarios.html
+++ b/Master/src/tracking-usuarios.html
@@ -193,6 +193,10 @@
                                 <label class="form-label text-primary fw-medium mb-1">Pode lançar avulso</label>
                                 <div id="d-pode-lancar-avulso">—</div>
                             </div>
+                            <div class="col-md-6">
+                                <label class="form-label text-primary fw-medium mb-1">Obriga foto no avulso</label>
+                                <div id="d-avulso-exige-foto">—</div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -414,6 +418,15 @@
                                     <input class="form-check-input" type="checkbox" id="podeLancarAvulso" checked>
                                     <label class="form-check-label" for="podeLancarAvulso">Pode lançar avulso</label>
                                     <div class="form-text">Ativo por padrão. Desmarque para bloquear o lançamento de avulso no app deste entregador.</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 d-none" id="avulsoExigeFotoWrap">
+                            <div class="mb-3">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="avulsoExigeFoto">
+                                    <label class="form-check-label" for="avulsoExigeFoto">Obriga foto?</label>
+                                    <div class="form-text">Exige foto ao lançar avulso na web ou no app deste entregador.</div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Resumo

Adiciona galeria multi-imagem no lightbox de registros, toggle “Obriga foto?” no admin de usuários, upload de foto no lançamento de avulso na leitura web e thumbs do evento `lancar_avulso` no histórico.

## Tipo de alteração

- [x] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Lightbox de comprovantes com prev/next, contador `i/n`, teclado e swipe
- Toggle “Obriga foto?” (visível só com “Pode lançar avulso” on; default off)
- Leitura web: quando o motoboy exige foto, faz presign pending → PUT B2 → `lancar-avulso` com `foto_object_key`
- Histórico associa fotos `lancar_avulso` ao evento correspondente

## Como testar

- Abrir registro com várias fotos e navegar no lightbox (setas, teclado, swipe)
- Em Usuários (motoboy): ligar “Pode lançar avulso” e “Obriga foto?”; salvar e reabrir
- Na leitura de saídas, lançar avulso para motoboy com obriga foto (deve exigir arquivo)
- Conferir thumb no evento “Lançou avulso” no histórico

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [ ] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Dependência

Requer backend da mesma branch (`fix/homolog-contadores-conferencia-avulso-destino`), inclusive migration `avulso_exige_foto` e campos em `GET /users/motoboys`.

## Rollback

Reverter o merge desta branch no frontend web.


Made with [Cursor](https://cursor.com)