### PR TITLE
feat: lote Obriga foto no avulso para todos os motoboys

### DIFF
--- a/Master/src/assets/js/pages/tracking-usuarios.js
+++ b/Master/src/assets/js/pages/tracking-usuarios.js
@@ -151,6 +151,10 @@ function initUsers() {
     if (btnPermAvulso) {
         btnPermAvulso.addEventListener("click", aplicarPermissaoAvulsoLote);
     }
+    const btnPermAvulsoFoto = document.getElementById("btnPermAvulsoFotoLote");
+    if (btnPermAvulsoFoto) {
+        btnPermAvulsoFoto.addEventListener("click", aplicarPermissaoAvulsoExigeFotoLote);
+    }
 
     document.getElementById("toggleAtivos").addEventListener("change", applyFilters);
     document.getElementById("search").addEventListener("input", applyFilters);
@@ -1049,6 +1053,71 @@ async function aplicarPermissaoAvulsoLote() {
         await Swal.fire({
             icon: "success",
             title: liberar ? "Avulso liberado" : "Avulso bloqueado",
+            text: `${data.atualizados ?? 0} entregador(es) atualizado(s).`,
+            timer: 2200,
+            showConfirmButton: false,
+        });
+        loadUsers();
+    } catch (err) {
+        await Swal.fire({
+            icon: "error",
+            title: "Erro inesperado",
+            text: err.message || "Falha ao atualizar permissões.",
+        });
+    }
+}
+
+async function aplicarPermissaoAvulsoExigeFotoLote() {
+    const escolha = await Swal.fire({
+        icon: "question",
+        title: "Obriga foto no avulso — todos os motoboys",
+        html: `
+            <p class="mb-2">Aplica a obrigatoriedade de foto a <strong>todos os entregadores</strong> desta base.</p>
+            <p class="text-muted small mb-0">Só vale para quem já pode lançar avulso. Motoboys precisarão entrar novamente no app para o token refletir a mudança.</p>
+        `,
+        showDenyButton: true,
+        showCancelButton: true,
+        confirmButtonText: "Exigir foto para todos",
+        denyButtonText: "Não exigir para todos",
+        cancelButtonText: "Cancelar",
+    });
+
+    if (!escolha.isConfirmed && !escolha.isDenied) return;
+
+    const exigir = !!escolha.isConfirmed;
+    try {
+        const resp = await fetch(`${API}/motoboys/permissoes-lote`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ avulso_exige_foto: exigir }),
+        });
+
+        if (!resp.ok) {
+            if (resp.status === 401) {
+                await Swal.fire({
+                    icon: "warning",
+                    title: "Sessão expirada",
+                    text: "Faça login novamente para continuar.",
+                });
+                location.href = "login.html";
+                return;
+            }
+            let mensagem = "Erro ao atualizar permissões.";
+            try {
+                const json = await resp.json();
+                if (json.detail) {
+                    mensagem = typeof json.detail === "string" ? json.detail : JSON.stringify(json.detail);
+                }
+            } catch {}
+            await Swal.fire({ icon: "error", title: "Falha", text: mensagem });
+            return;
+        }
+
+        const data = await resp.json().catch(() => ({}));
+        await Swal.fire({
+            icon: "success",
+            title: exigir ? "Foto obrigatória ativada" : "Foto obrigatória desativada",
             text: `${data.atualizados ?? 0} entregador(es) atualizado(s).`,
             timer: 2200,
             showConfirmButton: false,

--- a/Master/src/tracking-usuarios.html
+++ b/Master/src/tracking-usuarios.html
@@ -43,6 +43,10 @@
                             <button class="btn btn-soft-secondary" id="btnPermAvulsoLote" title="Aplicar permissão de lançar avulso a todos os motoboys da base">
                                 <i class="ri-group-line align-bottom me-1"></i> Avulso (todos)
                             </button>
+
+                            <button class="btn btn-soft-info" id="btnPermAvulsoFotoLote" title="Aplicar obrigatoriedade de foto no avulso a todos os motoboys da base">
+                                <i class="ri-camera-line align-bottom me-1"></i> Obriga foto (todos)
+                            </button>
                         </div>
 
                         <!-- Filtros direita -->


### PR DESCRIPTION
## Resumo

Adiciona ação em lote na tela de Usuários para exigir ou não exigir foto no lançamento de avulso para todos os motoboys da base, no mesmo padrão do botão Avulso (todos).

## Tipo de alteração

- [x] feature
- [ ] bug
- [ ] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Botão **Obriga foto (todos)** na barra de ações de Usuários
- Modal SweetAlert com opções Exigir / Não exigir / Cancelar
- Chama `POST /users/motoboys/permissoes-lote` com `{ avulso_exige_foto: true|false }`
- Texto deixa claro que só vale para quem já pode lançar avulso e que o app precisa relogar

## Como testar

- Abrir Usuários → clicar **Obriga foto (todos)** → Exigir foto para todos
- Confirmar toast de sucesso e, ao editar um motoboy com avulso liberado, ver **Obriga foto?** marcado
- Repetir com **Não exigir para todos** e validar que a flag volta para off
- Motoboy sem permissão de lançar avulso permanece sem obriga foto

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [ ] Requer atualização em outro repositório

## Checklist

- [ ] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Dependência

Backend já expõe `avulso_exige_foto` em `/users/motoboys/permissoes-lote` (merge da PR #54 / migration aplicada).

## Rollback

Reverter o merge desta branch.


Made with [Cursor](https://cursor.com)