### PR TITLE
fix: id_saida no presign-get para foto de avulso

### DIFF
--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -1491,7 +1491,7 @@ function setupPagerEvents() {
             method: "POST",
             credentials: "include",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ foto_urls: fotoUrls })
+            body: JSON.stringify({ foto_urls: fotoUrls, id_saida: Number(idSaida) || undefined })
           });
           if (presignRes.ok) {
             var presignData = await presignRes.json();


### PR DESCRIPTION
## Resumo

Ao abrir o detalhe do pedido, o `presign-get` passa a enviar `id_saida` junto com as `foto_urls`, para o backend autorizar keys `saida/pending/...` (foto no lançamento de avulso).

## Tipo de alteração

- [ ] feature
- [x] bug
- [x] fix
- [ ] chore
- [ ] docs
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- `tracking-registros.init.js`: inclui `id_saida` no body do `POST /upload/presign-get`

## Como testar

- Com backend da mesma branch/fix deployado
- Abrir avulso lançado com foto
- Miniatura aparece no evento \"Pedido adicionado\"

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [ ] Altera banco/migração
- [ ] Altera autenticação/permissões
- [ ] Altera integração externa
- [ ] Requer variável de ambiente

## Checklist

- [ ] Testei localmente
- [x] Revisei arquivos sensíveis como `.env`, tokens e chaves
- [ ] Atualizei documentação, se necessário
- [ ] Adicionei/atualizei migração, se necessário

## Dependência

Requer backend `fix/presign-get-foto-avulso-pending` (o backend também resolve pending sem `id_saida` via lookup na sub_base).

## Rollback

Reverter o merge desta branch.


Made with [Cursor](https://cursor.com)