### PR TITLE
feat: tela A Pagar e destaque de reajuste no fechamento

### DIFF
--- a/Master/src/assets/js/pages/tracking-contabilidade.init.js
+++ b/Master/src/assets/js/pages/tracking-contabilidade.init.js
@@ -335,7 +335,7 @@ document.addEventListener("DOMContentLoaded", () => {
       try {
       if (data.aviso_pendentes && avisoFechamentos && avisoFechamentosTexto) {
         avisoFechamentos.classList.remove("d-none");
-        avisoFechamentosTexto.textContent = "Há saídas no período sem fechamento GERADO/REAJUSTADO. Essas saídas já entram como \"Despesas pendentes\" e são consideradas no total, no lucro e na margem. Para convertê-las em despesas confirmadas, gere o fechamento na página Fechamento de Motoboys.";
+        avisoFechamentosTexto.textContent = "Há saídas no período sem fechamento GERADO/REAJUSTADO/PAGO. Essas saídas já entram como \"Despesas pendentes\" e são consideradas no total, no lucro e na margem. Para convertê-las em despesas confirmadas, gere o fechamento na página Fechamento de Motoboys.";
       } else if (avisoFechamentos) {
         avisoFechamentos.classList.add("d-none");
       }

--- a/Master/src/assets/js/pages/tracking-entregadores-a-pagar.init.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-a-pagar.init.js
@@ -1,0 +1,485 @@
+/* ======================================================
+   A Pagar — fechamentos consolidados + marcar como pago
+   GET  /api/entregadores/fechamentos
+   POST /api/entregadores/fechamentos/marcar-pago
+   ====================================================== */
+
+document.addEventListener("DOMContentLoaded", () => {
+  "use strict";
+
+  const API_URL = (window.TRACK_API_URL || "").replace(/\/+$/, "");
+  const API_FECHAMENTOS = `${API_URL}/entregadores/fechamentos`;
+
+  const qs = (s) => document.querySelector(s);
+  const formatarMoeda = (v) =>
+    new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(Number(v) || 0);
+
+  const STATUS_LABEL = {
+    GERADO: "Gerado",
+    REAJUSTADO: "Reajustado",
+    PAGO: "Pago",
+    FECHADO: "Gerado",
+  };
+
+  const state = {
+    items: [],
+    totais: {
+      total_a_pagar: 0,
+      total_pago: 0,
+      qtd_precisa_reajuste: 0,
+      qtd_a_pagar: 0,
+      qtd_pago: 0,
+    },
+  };
+
+  const fltDataInicio = qs("#flt-data-inicio");
+  const fltDataFim = qs("#flt-data-fim");
+  const fltStatus = qs("#flt-status");
+  const fltDivergencia = qs("#flt-apenas-divergencia");
+  const tbody = qs("#tbody-a-pagar");
+  const msgEl = qs("#aPagarMsg");
+  const btnMarcarPago = qs("#btnMarcarPago");
+  const filtrosContador = qs("#filtrosContador");
+
+  function updatePeriodLabel(start, end) {
+    const label = document.getElementById("a-pagar-period-label");
+    if (!label || !start || !end) return;
+    const [y1, m1, d1] = start.split("-");
+    const [y2, m2, d2] = end.split("-");
+    label.textContent = `${d1}/${m1}/${y1} – ${d2}/${m2}/${y2}`;
+  }
+
+  function atualizarContadorFiltros() {
+    if (!filtrosContador) return;
+    let n = 0;
+    if ((fltStatus?.value || "").trim()) n++;
+    if (fltDivergencia?.checked) n++;
+    if (n > 0) {
+      filtrosContador.textContent = String(n);
+      filtrosContador.classList.remove("d-none");
+    } else {
+      filtrosContador.classList.add("d-none");
+    }
+  }
+
+  function statusBadge(item) {
+    const st = String(item.status || "").toUpperCase();
+    const label = STATUS_LABEL[st] || st || "—";
+    if (st === "PAGO") {
+      return `<span class="badge bg-primary-subtle text-primary">${label}</span>`;
+    }
+    if (st === "REAJUSTADO") {
+      return `<span class="badge bg-info-subtle text-info">${label}</span>`;
+    }
+    if (st === "GERADO" || st === "FECHADO") {
+      return `<span class="badge bg-success-subtle text-success">${label}</span>`;
+    }
+    return `<span class="badge bg-secondary-subtle text-secondary">${label}</span>`;
+  }
+
+  function fmtPeriodo(inicio, fim) {
+    if (!inicio || !fim) return "—";
+    const f = (s) => {
+      const [y, m, d] = String(s).split("-");
+      return `${d}/${m}`;
+    };
+    return `${f(inicio)} a ${f(fim)}`;
+  }
+
+  function updateCards(totais) {
+    const t = totais || {};
+    const elA = qs("#card-a-pagar");
+    const elAQ = qs("#card-a-pagar-qtd");
+    const elP = qs("#card-pago");
+    const elPQ = qs("#card-pago-qtd");
+    const elR = qs("#card-reajuste");
+    if (elA) elA.textContent = formatarMoeda(t.total_a_pagar);
+    if (elAQ) elAQ.textContent = `${t.qtd_a_pagar || 0} fechamento(s)`;
+    if (elP) elP.textContent = formatarMoeda(t.total_pago);
+    if (elPQ) elPQ.textContent = `${t.qtd_pago || 0} fechamento(s)`;
+    if (elR) elR.textContent = String(t.qtd_precisa_reajuste || 0);
+  }
+
+  function elegiveis() {
+    return (state.items || []).filter((i) => {
+      const st = String(i.status || "").toUpperCase();
+      return st === "GERADO" || st === "REAJUSTADO";
+    });
+  }
+
+  function renderTable(items) {
+    if (!tbody) return;
+    if (!items || !items.length) {
+      tbody.innerHTML =
+        '<tr><td colspan="7" class="text-center text-muted py-4">Nenhum fechamento neste período.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = items
+      .map((item) => {
+        const precisa = !!item.precisa_reajuste;
+        const alertaPago = !!item.alerta_pos_pago;
+        const rowClass = precisa ? "table-warning" : alertaPago ? "table-secondary" : "";
+        const pix = (item.chave_pix || "").trim() || "—";
+        const pdfBtn = item.id_fechamento
+          ? `<button type="button" class="btn btn-sm btn-soft-secondary btn-pdf" data-id="${item.id_fechamento}" title="Baixar PDF"><i class="ri-file-pdf-line"></i></button>`
+          : "—";
+        let acoes = "—";
+        if (precisa) {
+          acoes = `<button type="button" class="btn btn-sm btn-warning btn-reajustar" data-id="${item.id_fechamento}"><i class="ri-refresh-line me-1"></i>Gerar reajuste</button>`;
+        } else if (alertaPago) {
+          acoes = `<span class="badge bg-secondary-subtle text-secondary" title="Valor base mudou após o pagamento">Alerta pós-pago</span>`;
+        }
+        return (
+          `<tr class="${rowClass}" data-id="${item.id_fechamento}">` +
+          `<td>${(item.username_entregador || "—").replace(/</g, "&lt;")}</td>` +
+          `<td>${fmtPeriodo(item.periodo_inicio, item.periodo_fim)}</td>` +
+          `<td class="text-end fw-semibold">${formatarMoeda(item.valor_final)}</td>` +
+          `<td>${statusBadge(item)}${precisa ? ' <span class="badge bg-warning text-dark">Precisa reajuste</span>' : ""}</td>` +
+          `<td class="small text-break" style="max-width:160px">${pix.replace(/</g, "&lt;")}</td>` +
+          `<td class="text-center">${pdfBtn}</td>` +
+          `<td class="text-center">${acoes}</td>` +
+          `</tr>`
+        );
+      })
+      .join("");
+  }
+
+  async function fetchJson(url, options) {
+    const res = await fetch(url, { credentials: "include", ...(options || {}) });
+    if (res.status === 401) {
+      window.location.href = "auth-signin-tracking-v2.html";
+      throw new Error("Sessão expirada.");
+    }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const err = new Error(
+        typeof data.detail === "string"
+          ? data.detail
+          : data.detail?.message || data.message || `HTTP ${res.status}`
+      );
+      err.status = res.status;
+      err.detail = data.detail;
+      throw err;
+    }
+    return data;
+  }
+
+  async function carregarLista() {
+    const inicio = (fltDataInicio?.value || "").trim();
+    const fim = (fltDataFim?.value || "").trim();
+    if (!inicio || !fim) return;
+    if (!API_URL) {
+      if (msgEl) msgEl.innerHTML = '<div class="text-danger">URL da API não configurada.</div>';
+      return;
+    }
+    if (msgEl) msgEl.innerHTML = '<div class="text-muted">Carregando…</div>';
+    try {
+      const params = new URLSearchParams({
+        periodo_inicio: inicio,
+        periodo_fim: fim,
+      });
+      const st = (fltStatus?.value || "").trim();
+      if (st) params.append("status", st);
+      if (fltDivergencia?.checked) params.append("apenas_com_divergencia", "true");
+
+      const data = await fetchJson(`${API_FECHAMENTOS}?${params.toString()}`);
+      state.items = data.items || [];
+      state.totais = data.totais || {};
+      updateCards(state.totais);
+      renderTable(state.items);
+      if (btnMarcarPago) btnMarcarPago.disabled = elegiveis().length === 0;
+      atualizarContadorFiltros();
+      if (msgEl) msgEl.innerHTML = "";
+    } catch (err) {
+      console.error("A Pagar — carregarLista:", err);
+      if (msgEl) {
+        msgEl.innerHTML =
+          '<div class="text-danger">' +
+          String(err.message || "Erro ao carregar.").replace(/</g, "&lt;") +
+          "</div>";
+      }
+      state.items = [];
+      state.totais = {
+        total_a_pagar: 0,
+        total_pago: 0,
+        qtd_precisa_reajuste: 0,
+        qtd_a_pagar: 0,
+        qtd_pago: 0,
+      };
+      updateCards(state.totais);
+      renderTable([]);
+      if (btnMarcarPago) btnMarcarPago.disabled = true;
+    }
+  }
+
+  async function confirmarDivergencia(qtd) {
+    const msg =
+      qtd === 1
+        ? "Há 1 fechamento com valor base divergente. Deseja marcar como pago mesmo assim?"
+        : `Há ${qtd} fechamentos com valor base divergente. Deseja marcar como pago mesmo assim?`;
+    if (window.Swal) {
+      const r = await Swal.fire({
+        icon: "warning",
+        title: "Confirmar pagamento com divergência",
+        html: msg,
+        showCancelButton: true,
+        confirmButtonText: "Sim, marcar como pago",
+        cancelButtonText: "Cancelar",
+        confirmButtonColor: "#f59e0b",
+      });
+      return !!r.isConfirmed;
+    }
+    return confirm(msg);
+  }
+
+  async function executarMarcarPago({ todosElegiveis, ids, confirmarComDivergencia }) {
+    const inicio = (fltDataInicio?.value || "").trim();
+    const fim = (fltDataFim?.value || "").trim();
+    const body = {
+      periodo_inicio: inicio,
+      periodo_fim: fim,
+      todos_elegiveis: !!todosElegiveis,
+      ids_fechamento: todosElegiveis ? null : ids,
+      confirmar_com_divergencia: !!confirmarComDivergencia,
+    };
+    try {
+      const data = await fetchJson(`${API_FECHAMENTOS}/marcar-pago`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (window.Swal) {
+        await Swal.fire({
+          icon: "success",
+          title: "Pagamento registrado",
+          text: `${data.marcados || 0} fechamento(s) marcado(s) como pago.`,
+        });
+      }
+      await carregarLista();
+    } catch (err) {
+      if (err.status === 409 && err.detail && err.detail.divergentes) {
+        const ok = await confirmarDivergencia(err.detail.divergentes.length);
+        if (!ok) return;
+        return executarMarcarPago({
+          todosElegiveis,
+          ids,
+          confirmarComDivergencia: true,
+        });
+      }
+      const msg = err.message || "Não foi possível marcar como pago.";
+      if (window.Swal) Swal.fire({ icon: "error", title: "Erro", text: msg });
+      else alert(msg);
+    }
+  }
+
+  function abrirModalSelecao() {
+    const lista = elegiveis().slice().sort((a, b) =>
+      String(a.username_entregador || "").localeCompare(
+        String(b.username_entregador || ""),
+        "pt-BR",
+        { sensitivity: "base" }
+      )
+    );
+    const container = qs("#listaSelecaoMotoboys");
+    if (!container) return;
+    if (!lista.length) {
+      container.innerHTML = '<p class="text-muted mb-0">Nenhum fechamento elegível.</p>';
+    } else {
+      container.innerHTML = lista
+        .map((item) => {
+          const nome = (item.username_entregador || "—").replace(/</g, "&lt;");
+          const warn = item.precisa_reajuste
+            ? ' <span class="badge bg-warning text-dark">divergência</span>'
+            : "";
+          return (
+            `<div class="form-check border rounded px-3 py-2">` +
+            `<input class="form-check-input chk-motoboy-pago" type="checkbox" value="${item.id_fechamento}" id="chk-fech-${item.id_fechamento}">` +
+            `<label class="form-check-label w-100" for="chk-fech-${item.id_fechamento}">` +
+            `<strong>${nome}</strong>${warn}` +
+            `<span class="float-end">${formatarMoeda(item.valor_final)}</span>` +
+            `</label></div>`
+          );
+        })
+        .join("");
+    }
+    const modalEl = qs("#modalSelecionarMotoboys");
+    if (modalEl && typeof bootstrap !== "undefined") {
+      bootstrap.Modal.getOrCreateInstance(modalEl).show();
+    }
+  }
+
+  async function fluxoMarcarPago() {
+    const list = elegiveis();
+    if (!list.length) return;
+
+    let todos = false;
+    if (window.Swal) {
+      const r = await Swal.fire({
+        icon: "question",
+        title: "Marcar como pago",
+        html: "Todos os motoboys com fechamento gerado neste período?",
+        showDenyButton: true,
+        showCancelButton: true,
+        confirmButtonText: "Sim, todos",
+        denyButtonText: "Não, selecionar",
+        cancelButtonText: "Cancelar",
+      });
+      if (r.isDismissed) return;
+      todos = !!r.isConfirmed;
+      if (r.isDenied) {
+        abrirModalSelecao();
+        return;
+      }
+    } else {
+      todos = confirm("Todos os motoboys com fechamento gerado neste período?");
+      if (!todos) {
+        abrirModalSelecao();
+        return;
+      }
+    }
+
+    await executarMarcarPago({ todosElegiveis: true, ids: null, confirmarComDivergencia: false });
+  }
+
+  async function reajustarFechamento(idFechamento) {
+    try {
+      const data = await fetchJson(`${API_FECHAMENTOS}/${idFechamento}`);
+      const temDiv = !!data.divergencia_valor_base;
+      let html =
+        `<p class="mb-2"><strong>${(data.username_entregador || "").replace(/</g, "&lt;")}</strong></p>` +
+        `<p class="mb-1">Valor base atual: <strong>${formatarMoeda(data.valor_base)}</strong></p>`;
+      if (temDiv) {
+        html +=
+          `<p class="mb-1 text-warning">Novo valor base calculado: <strong>${formatarMoeda(
+            data.valor_base_recalculado
+          )}</strong></p>` +
+          `<p class="small text-muted">O valor base será atualizado e o status passará para Reajustado.</p>`;
+      } else {
+        html += `<p class="small text-muted">Não há divergência de valor base. Confirme para registrar o reajuste.</p>`;
+      }
+
+      let ok = true;
+      if (window.Swal) {
+        const r = await Swal.fire({
+          icon: "warning",
+          title: "Gerar reajuste",
+          html,
+          showCancelButton: true,
+          confirmButtonText: "Confirmar reajuste",
+          cancelButtonText: "Cancelar",
+        });
+        ok = !!r.isConfirmed;
+      } else {
+        ok = confirm("Confirmar reajuste deste fechamento?");
+      }
+      if (!ok) return;
+
+      await fetchJson(`${API_FECHAMENTOS}/${idFechamento}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          atualizar_valor_base: temDiv ? true : false,
+        }),
+      });
+
+      if (window.Swal) {
+        await Swal.fire({ icon: "success", title: "Reajuste salvo", text: "Fechamento atualizado." });
+      }
+      await carregarLista();
+    } catch (err) {
+      const msg = err.message || "Erro ao reajustar.";
+      if (window.Swal) Swal.fire({ icon: "error", title: "Erro", text: msg });
+      else alert(msg);
+    }
+  }
+
+  // Events
+  if (btnMarcarPago) btnMarcarPago.addEventListener("click", () => fluxoMarcarPago());
+
+  const btnConfirmarSelecao = qs("#btnConfirmarSelecaoPago");
+  if (btnConfirmarSelecao) {
+    btnConfirmarSelecao.addEventListener("click", async () => {
+      const ids = Array.from(document.querySelectorAll(".chk-motoboy-pago:checked")).map((el) =>
+        Number(el.value)
+      );
+      if (!ids.length) {
+        if (window.Swal) Swal.fire({ icon: "info", title: "Selecione ao menos um motoboy" });
+        else alert("Selecione ao menos um motoboy.");
+        return;
+      }
+      const modalEl = qs("#modalSelecionarMotoboys");
+      if (modalEl && typeof bootstrap !== "undefined") {
+        bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+      }
+      await executarMarcarPago({
+        todosElegiveis: false,
+        ids,
+        confirmarComDivergencia: false,
+      });
+    });
+  }
+
+  if (tbody) {
+    tbody.addEventListener("click", (ev) => {
+      const pdfBtn = ev.target.closest(".btn-pdf");
+      if (pdfBtn) {
+        const id = Number(pdfBtn.getAttribute("data-id"));
+        if (window.TrackSaidasFechamentoPdf && id) {
+          window.TrackSaidasFechamentoPdf.gerar(id);
+        }
+        return;
+      }
+      const rejBtn = ev.target.closest(".btn-reajustar");
+      if (rejBtn) {
+        const id = Number(rejBtn.getAttribute("data-id"));
+        if (id) reajustarFechamento(id);
+      }
+    });
+  }
+
+  qs("#btnFiltroAplicar")?.addEventListener("click", () => {
+    atualizarContadorFiltros();
+    carregarLista();
+  });
+  qs("#btnFiltroLimpar")?.addEventListener("click", () => {
+    if (fltStatus) fltStatus.value = "";
+    if (fltDivergencia) fltDivergencia.checked = false;
+    atualizarContadorFiltros();
+    carregarLista();
+  });
+
+  // Date picker
+  let datePickerInstance = null;
+  const periodBtn = document.getElementById("a-pagar-period-btn");
+  if (typeof window.initDatePickerDashboard === "function") {
+    datePickerInstance = window.initDatePickerDashboard({
+      containerId: "a-pagar-date-picker-container",
+      prefix: "a-pagar-dp",
+      defaultPreset: "quinzena-ant",
+      onApply: function (start, end) {
+        if (fltDataInicio) fltDataInicio.value = start;
+        if (fltDataFim) fltDataFim.value = end;
+        updatePeriodLabel(start, end);
+        if (typeof bootstrap !== "undefined" && bootstrap.Dropdown && periodBtn) {
+          const d = bootstrap.Dropdown.getInstance(periodBtn);
+          if (d) d.hide();
+        }
+        carregarLista();
+      },
+      onCancel: function () {
+        if (typeof bootstrap !== "undefined" && bootstrap.Dropdown && periodBtn) {
+          const d = bootstrap.Dropdown.getInstance(periodBtn);
+          if (d) d.hide();
+        }
+      },
+    });
+    if (datePickerInstance && datePickerInstance.applyPreset) {
+      datePickerInstance.applyPreset("quinzena-ant");
+    }
+    const r = datePickerInstance ? datePickerInstance.getResolvedRange() : { start: "", end: "" };
+    if (fltDataInicio) fltDataInicio.value = r.start;
+    if (fltDataFim) fltDataFim.value = r.end;
+    updatePeriodLabel(r.start, r.end);
+    carregarLista();
+  }
+});

--- a/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
@@ -91,6 +91,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     PENDENTE: "Sem fechamento para o período",
     GERADO: "Fechamento gerado",
     REAJUSTADO: "Fechamento reajustado",
+    PAGO: "Pagamento confirmado",
   };
 
   function formatarCodigoFechamento(r) {
@@ -140,11 +141,22 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (idFech) {
         html += ' <button type="button" class="btn btn-link btn-sm p-0 ms-1 btn-pdf-fechamento" title="Gerar PDF · ' + (codigoFech || "") + '" data-id-fech="' + idFech + '"><i class="ri-file-pdf-line text-danger"></i></button>';
       }
+    } else if (st === "PAGO") {
+      html = '<span class="badge bg-primary-subtle text-primary" title="' + (STATUS_TOOLTIPS.PAGO || "Pago") + (codigoFech ? " · " + codigoFech : "") + '">Pago</span>';
+      if (idFech) {
+        html += ' <button type="button" class="btn btn-link btn-sm p-0 ms-1 btn-pdf-fechamento" title="Gerar PDF · ' + (codigoFech || "") + '" data-id-fech="' + idFech + '"><i class="ri-file-pdf-line text-danger"></i></button>';
+      }
+      if (r.alerta_pos_pago) {
+        html += ' <span class="badge bg-secondary-subtle text-secondary" title="Valor base mudou após o pagamento">Alerta</span>';
+      }
     } else {
       html = '<span class="badge bg-info-subtle text-info" title="' + (STATUS_TOOLTIPS.REAJUSTADO || "Reajustado") + (codigoFech ? " · " + codigoFech : "") + '">🔵 REAJUSTADO</span>';
       if (idFech) {
         html += ' <button type="button" class="btn btn-link btn-sm p-0 ms-1 btn-pdf-fechamento" title="Gerar PDF · ' + (codigoFech || "") + '" data-id-fech="' + idFech + '"><i class="ri-file-pdf-line text-danger"></i></button>';
       }
+    }
+    if (r.pode_reajustar) {
+      html += ' <span class="badge bg-warning text-dark" title="Valor base divergente — gere o reajuste">Gerar reajuste</span>';
     }
     return html;
   }
@@ -267,18 +279,20 @@ document.addEventListener("DOMContentLoaded", async () => {
     const ctx = state.contextoFechamento;
     const listaReajuste = state.entregadoresParaReajuste || [];
     const statusFiltro = (fltStatus?.value || "").trim().toUpperCase();
-    // Reajustar habilitado só por status GERADO: um contexto único ou vários entregadores para escolher
-    const podeReajustarSóStatus = statusFiltro === "GERADO" && (ctx?.id_fechamento || listaReajuste.length > 0);
+    // Reajustar quando filtro GERADO ou REAJUSTADO e há fechamento(s) no contexto
+    const podeReajustarSóStatus =
+      (statusFiltro === "GERADO" || statusFiltro === "REAJUSTADO") &&
+      (ctx?.id_fechamento || listaReajuste.length > 0);
     const status = podeReajustarSóStatus ? "GERADO" : "PENDENTE";
 
     if (!temPeriodo && !podeReajustarSóStatus) {
       btn.disabled = true;
       btn.innerHTML = '<i class="ri-file-add-line me-1"></i> Gerar Fechamento';
       wrap.title = "Selecione um período para gerar ou reajustar o fechamento.";
-    } else if (status === "REAJUSTADO") {
+    } else if (statusFiltro === "PAGO") {
       btn.disabled = true;
-      btn.innerHTML = '<i class="ri-check-double-line me-1"></i> Reajustado';
-      wrap.title = "Este fechamento já foi reajustado.";
+      btn.innerHTML = '<i class="ri-checkbox-circle-line me-1"></i> Pago';
+      wrap.title = "Fechamentos pagos não podem ser reajustados.";
     } else if (status === "GERADO") {
       btn.disabled = false;
       btn.innerHTML = '<i class="ri-edit-line me-1"></i> Reajustar';
@@ -306,7 +320,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         opcoes.forEach((o) => { inputOptions[o.key] = o.nome; });
         const { value: selecionado } = await window.Swal.fire({
           title: "Selecione o motoboy",
-          html: "Há mais de um motoboy com fechamento GERADO. Escolha qual deseja reajustar.",
+          html: "Há mais de um motoboy com fechamento elegível. Escolha qual deseja reajustar.",
           showCancelButton: true,
           cancelButtonText: "Cancelar",
           confirmButtonText: "Reajustar",
@@ -412,9 +426,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         const valorCancelados = r.valor_cancelados != null ? formatarMoeda(r.valor_cancelados) : "—";
         const valorTotal = r.valor_total != null ? formatarMoeda(r.valor_total) : (r.total_dia != null ? formatarMoeda(r.total_dia) : "—");
         const celFech = celulaFechamento(r);
+        const rowClass = r.pode_reajustar ? "table-warning" : r.alerta_pos_pago ? "table-secondary" : "";
 
         return (
-          "<tr>" +
+          "<tr class=\"" + rowClass + "\">" +
           "<td class=\"text-nowrap\">" + formatarData(r.data) + "</td>" +
           "<td>" + (r.entregador_nome || "—") + "</td>" +
           '<td class="text-center">' + flexQtde + "</td>" +
@@ -961,7 +976,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           executorTipo: executor.tipo,
           executorId: executor.tipo === "e" ? primeiro.entregador_id : primeiro.motoboy_id,
         };
-      } else if (!temExecutor && statusFiltro === "GERADO" && state.items.length > 0) {
+      } else if (!temExecutor && (statusFiltro === "GERADO" || statusFiltro === "REAJUSTADO") && state.items.length > 0) {
         const seen = new Set();
         const lista = [];
         state.items.forEach((i) => {
@@ -985,10 +1000,20 @@ document.addEventListener("DOMContentLoaded", async () => {
         state.entregadoresParaReajuste = lista.filter((e) => e.id_fechamento != null);
         if (lista.length === 1 && state.entregadoresParaReajuste.length === 1) {
           const u = state.entregadoresParaReajuste[0];
-          state.contextoFechamento = { status: "GERADO", id_fechamento: u.id_fechamento, periodo_inicio: u.periodo_inicio, periodo_fim: u.periodo_fim, entregador_nome: u.entregador_nome, executorTipo: u.executorTipo, executorId: u.executorId };
+          state.contextoFechamento = {
+            status: statusFiltro,
+            id_fechamento: u.id_fechamento,
+            periodo_inicio: u.periodo_inicio,
+            periodo_fim: u.periodo_fim,
+            entregador_nome: u.entregador_nome,
+            executorTipo: u.executorTipo,
+            executorId: u.executorId,
+          };
           state.entregadoresParaReajuste = [];
         } else {
-          state.contextoFechamento = state.entregadoresParaReajuste.length > 0 ? { status: "GERADO", id_fechamento: null, periodo_inicio: dataInicio, periodo_fim: dataFim, entregador_nome: "" } : null;
+          state.contextoFechamento = state.entregadoresParaReajuste.length > 0
+            ? { status: statusFiltro, id_fechamento: null, periodo_inicio: dataInicio, periodo_fim: dataFim, entregador_nome: "" }
+            : null;
         }
       } else {
         state.contextoFechamento = temExecutor && dataInicio && dataFim ? { status: "PENDENTE", id_fechamento: null, periodo_inicio: dataInicio, periodo_fim: dataFim, entregador_nome: label } : null;
@@ -1086,7 +1111,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     const statusFiltro = (fltStatus?.value || "").trim().toUpperCase();
     const ctx = state.contextoFechamento;
     const listaReajuste = state.entregadoresParaReajuste || [];
-    const podeReajustar = statusFiltro === "GERADO" && (ctx?.id_fechamento || listaReajuste.length > 0);
+    const podeReajustar =
+      (statusFiltro === "GERADO" || statusFiltro === "REAJUSTADO") &&
+      (ctx?.id_fechamento || listaReajuste.length > 0);
     const acao = podeReajustar ? "reajustar" : "gerar";
     await executarAcaoFechamento(acao);
   });

--- a/Master/src/tracking-entregadores-a-pagar.html
+++ b/Master/src/tracking-entregadores-a-pagar.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    @@include("partials/title-meta.html", {"title": "TrackSaídas — A Pagar"})
+    @@include("partials/head-css.html")
+  </head>
+  <body data-layout="vertical" data-topbar="light" data-sidebar="dark">
+    <div id="layout-wrapper">
+      @@include("partials/menu.html")
+
+      <div class="main-content">
+        <div class="page-content">
+          <div class="container-fluid">
+
+            @@include("partials/page-title.html", {"pagetitle": "Financeiro", "title": "A Pagar", "withSubtitle": true, "ownerTerm": ""})
+
+            <div class="row">
+              <div class="col-12">
+                <div class="card">
+                  <div class="card-body">
+                    <div class="row g-3 align-items-center mb-3">
+                      <div class="col-md-auto d-flex gap-2 flex-wrap">
+                        <button type="button" id="btnMarcarPago" class="btn btn-success" disabled>
+                          <i class="ri-checkbox-circle-line me-1"></i> Marcar como pago
+                        </button>
+                        <a href="tracking-entregadores-resumo.html" class="btn btn-outline-secondary">
+                          <i class="ri-file-list-3-line me-1"></i> Fechamento de Motoboys
+                        </a>
+                      </div>
+                      <div class="col-md-auto ms-auto d-flex gap-2 flex-wrap align-items-center">
+                        <div class="dropdown">
+                          <button class="btn btn-soft-primary dropdown-toggle d-flex align-items-center gap-2" type="button" id="a-pagar-period-btn" data-bs-toggle="dropdown" data-bs-auto-close="outside">
+                            <i class="bx bx-calendar"></i>
+                            <span id="a-pagar-period-label" class="text-truncate">Quinzena anterior</span>
+                          </button>
+                          <div class="dropdown-menu dropdown-menu-end p-0" id="a-pagar-period-panel" style="min-width: 640px;">
+                            <input type="hidden" id="flt-data-inicio" />
+                            <input type="hidden" id="flt-data-fim" />
+                            <div id="a-pagar-date-picker-container"></div>
+                          </div>
+                        </div>
+                        <div class="dropdown">
+                          <button class="btn btn-outline-secondary position-relative" id="btnFiltrosIcon" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside">
+                            <i class="ri-filter-3-line me-1"></i> Filtros
+                            <span id="filtrosContador" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary d-none">0</span>
+                          </button>
+                          <div class="dropdown-menu dropdown-menu-end p-3" style="min-width: 280px;">
+                            <div class="mb-3">
+                              <label class="form-label small">Situação</label>
+                              <select id="flt-status" class="form-select form-select-sm">
+                                <option value="">(Todos)</option>
+                                <option value="GERADO">Gerado</option>
+                                <option value="REAJUSTADO">Reajustado</option>
+                                <option value="PAGO">Pago</option>
+                              </select>
+                            </div>
+                            <div class="form-check mb-3">
+                              <input class="form-check-input" type="checkbox" id="flt-apenas-divergencia">
+                              <label class="form-check-label small" for="flt-apenas-divergencia">Somente com divergência</label>
+                            </div>
+                            <div class="d-flex gap-2">
+                              <button type="button" id="btnFiltroAplicar" class="btn btn-primary flex-grow-1">Aplicar</button>
+                              <button type="button" id="btnFiltroLimpar" class="btn btn-outline-secondary flex-grow-1">Limpar</button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div id="aPagarMsg" class="mb-3"></div>
+
+                    <div class="row g-2 mb-3">
+                      <div class="col-md-4">
+                        <div class="p-3 rounded text-center bg-success bg-opacity-10">
+                          <span class="text-uppercase small text-secondary fw-semibold d-block">Total a pagar</span>
+                          <span class="fs-5 fw-bold text-success" id="card-a-pagar">R$ 0,00</span>
+                          <span class="small text-muted d-block" id="card-a-pagar-qtd">0 fechamento(s)</span>
+                        </div>
+                      </div>
+                      <div class="col-md-4">
+                        <div class="p-3 rounded text-center bg-primary bg-opacity-10">
+                          <span class="text-uppercase small text-secondary fw-semibold d-block">Já pagos</span>
+                          <span class="fs-5 fw-bold text-primary" id="card-pago">R$ 0,00</span>
+                          <span class="small text-muted d-block" id="card-pago-qtd">0 fechamento(s)</span>
+                        </div>
+                      </div>
+                      <div class="col-md-4">
+                        <div class="p-3 rounded text-center bg-warning bg-opacity-10">
+                          <span class="text-uppercase small text-secondary fw-semibold d-block">Precisam reajuste</span>
+                          <span class="fs-5 fw-bold text-warning" id="card-reajuste">0</span>
+                          <span class="small text-muted d-block">Com valor base divergente</span>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div class="table-responsive">
+                      <table class="table table-hover align-middle mb-0" id="tbl-a-pagar">
+                        <thead class="table-light">
+                          <tr>
+                            <th>Motoboy</th>
+                            <th>Período</th>
+                            <th class="text-end">Valor</th>
+                            <th>Situação</th>
+                            <th>PIX</th>
+                            <th class="text-center">PDF</th>
+                            <th class="text-center">Ações</th>
+                          </tr>
+                        </thead>
+                        <tbody id="tbody-a-pagar">
+                          <tr><td colspan="7" class="text-center text-muted py-4">Selecione o período para carregar.</td></tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+        @@include("partials/footer.html")
+      </div>
+    </div>
+
+    <!-- Modal seleção motoboys -->
+    <div class="modal fade" id="modalSelecionarMotoboys" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Selecionar motoboys</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <div class="modal-body">
+            <p class="small text-muted">Selecione quais fechamentos deseja marcar como pagos. Por padrão, nenhum vem marcado.</p>
+            <div id="listaSelecaoMotoboys" class="d-flex flex-column gap-2"></div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="button" class="btn btn-success" id="btnConfirmarSelecaoPago">
+              <i class="ri-checkbox-circle-line me-1"></i> Confirmar
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="vertical-overlay"></div>
+    @@include("partials/customizer.html")
+    @@include("partials/vendor-scripts.html")
+
+    <script>
+      if (!window.TRACK_API_URL) window.TRACK_API_URL = "https://track-saidas-api.onrender.com/api";
+    </script>
+    <script src="assets/js/components/date-picker-dashboard.js"></script>
+    <script src="assets/js/pages/tracking-entregadores-fechamento-pdf.js"></script>
+    <script src="assets/js/pages/tracking-entregadores-a-pagar.init.js?v=1"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
+</html>

--- a/Master/src/tracking-entregadores-resumo.html
+++ b/Master/src/tracking-entregadores-resumo.html
@@ -58,6 +58,7 @@
                                   <option value="PENDENTE">PENDENTE</option>
                                   <option value="GERADO">GERADO</option>
                                   <option value="REAJUSTADO">REAJUSTADO</option>
+                                  <option value="PAGO">PAGO</option>
                                 </select>
                               </div>
                               <div class="d-flex gap-2">
@@ -283,7 +284,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js"></script>
     <script src="assets/js/components/date-picker-dashboard.js"></script>
     <script src="assets/js/pages/tracking-entregadores-fechamento-pdf.js"></script>
-    <script src="assets/js/pages/tracking-entregadores-resumo.init.js?v=2"></script>
+    <script src="assets/js/pages/tracking-entregadores-resumo.init.js?v=3"></script>
     <script src="assets/js/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Resumo

Cria a tela Financeiro **A Pagar** com totais, marcação de pagamento (todos ou seleção) e destaque de reajuste; atualiza o Fechamento de Motoboys para reajuste após `REAJUSTADO`, filtro `PAGO` e alerta visual.

## Tipo de alteração

- [x] feature
- [ ] bug
- [ ] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Nova página `tracking-entregadores-a-pagar.html` + init JS
- Fluxo Marcar como pago: todos do período ou checklist alfabética (desmarcada)
- Confirmação explícita ao pagar com divergência
- Resumo: filtro `PAGO`, reajuste em `REAJUSTADO`, linhas destacadas
- Ajuste de texto na Contabilidade para incluir `PAGO`

## Como testar

- Abrir **A Pagar** no menu Financeiro (requer backend desta feature)
- Conferir cards e tabela por quinzena
- Marcar como pago (todos / seleção) e fluxo de divergência
- No Fechamento de Motoboys: filtrar `REAJUSTADO`/`PAGO` e ver destaque de reajuste

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

**Dependência:** PR do backend `track_saidas` (branch `feat/fechamento-a-pagar`).


Made with [Cursor](https://cursor.com)