### PR TITLE
fix: melhora erro da tela A Pagar (HTTP 422)

### DIFF
--- a/Master/src/assets/js/pages/tracking-entregadores-a-pagar.init.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-a-pagar.init.js
@@ -152,13 +152,25 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     const data = await res.json().catch(() => ({}));
     if (!res.ok) {
-      const err = new Error(
-        typeof data.detail === "string"
-          ? data.detail
-          : data.detail?.message || data.message || `HTTP ${res.status}`
-      );
+      let msg = data.message || `HTTP ${res.status}`;
+      const detail = data.detail;
+      if (typeof detail === "string") {
+        msg = detail;
+      } else if (detail && typeof detail === "object" && !Array.isArray(detail) && detail.message) {
+        msg = detail.message;
+      } else if (Array.isArray(detail) && detail.length) {
+        msg = detail
+          .map((item) => {
+            if (typeof item === "string") return item;
+            const loc = Array.isArray(item.loc) ? item.loc.filter((x) => x !== "body" && x !== "query").join(".") : "";
+            const text = item.msg || item.message || JSON.stringify(item);
+            return loc ? `${loc}: ${text}` : text;
+          })
+          .join(" | ");
+      }
+      const err = new Error(msg);
       err.status = res.status;
-      err.detail = data.detail;
+      err.detail = detail;
       throw err;
     }
     return data;

--- a/Master/src/tracking-entregadores-a-pagar.html
+++ b/Master/src/tracking-entregadores-a-pagar.html
@@ -153,7 +153,7 @@
     </script>
     <script src="assets/js/components/date-picker-dashboard.js"></script>
     <script src="assets/js/pages/tracking-entregadores-fechamento-pdf.js"></script>
-    <script src="assets/js/pages/tracking-entregadores-a-pagar.init.js?v=1"></script>
+    <script src="assets/js/pages/tracking-entregadores-a-pagar.init.js?v=2"></script>
     <script src="assets/js/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Resumo

Melhora o parse de erros de validação do FastAPI na tela A Pagar (exibe `msg` do array `detail` em vez de só \"HTTP 422\"). Cache-bust do JS (`?v=2`).

## Tipo de alteração

- [ ] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- `fetchJson` trata `detail` como array de validação
- Bump `?v=2` no script da página

## Como testar

- Abrir A Pagar após deploy do fix de rota no backend
- Em caso de erro de API, mensagem deve ser legível

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

**Dependência crítica:** PR do backend `fix/fechamento-a-pagar-rota-422` (ordem dos routers).


Made with [Cursor](https://cursor.com)