### PR TITLE
fix: oculta usuários excluídos e padroniza nomes nos filtros

### DIFF
--- a/Master/src/assets/js/pages/tracking-acompanhamento.init.js
+++ b/Master/src/assets/js/pages/tracking-acompanhamento.init.js
@@ -376,21 +376,28 @@
     if (!select) return;
     try {
       const list = await fetchWithCreds(API_MOTOBOYS);
-      const sorted = (Array.isArray(list) ? list : []).slice().sort((a, b) => {
-        const va = a?.id_motoboy != null ? a.id_motoboy : a?.id;
-        const vb = b?.id_motoboy != null ? b.id_motoboy : b?.id;
-        const la = String(a?.nome || `Motoboy ${va || ""}`);
-        const lb = String(b?.nome || `Motoboy ${vb || ""}`);
-        return la.localeCompare(lb, "pt-BR", { sensitivity: "base" });
-      });
+      const listNorm = (typeof window.normalizePersonList === "function")
+        ? window.normalizePersonList(Array.isArray(list) ? list : [])
+        : (Array.isArray(list) ? list : []).slice().sort((a, b) => {
+            const va = a?.id_motoboy != null ? a.id_motoboy : a?.id;
+            const vb = b?.id_motoboy != null ? b.id_motoboy : b?.id;
+            const la = String(a?.nome || `Motoboy ${va || ""}`);
+            const lb = String(b?.nome || `Motoboy ${vb || ""}`);
+            return la.localeCompare(lb, "pt-BR", { sensitivity: "base" });
+          });
 
       const uniqueByNome = new Map();
-      sorted.forEach((m) => {
+      listNorm.forEach((m) => {
         const val = m?.id_motoboy != null ? m.id_motoboy : m?.id;
-        const label = String(m?.nome || `Motoboy ${val || ""}`);
-        const key = normalizeNomeKey(label);
+        const labelRaw = String(m?.nome || `Motoboy ${val || ""}`);
+        const label = (typeof window.formatPersonName === "function")
+          ? window.formatPersonName(labelRaw)
+          : labelRaw;
+        const key = (typeof window.personNameKey === "function")
+          ? window.personNameKey(label)
+          : normalizeNomeKey(label);
         if (!key || uniqueByNome.has(key)) return;
-        uniqueByNome.set(key, m);
+        uniqueByNome.set(key, { ...m, nome: label });
       });
 
       const opts = Array.from(uniqueByNome.values())

--- a/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-api-leitura-registros.init.js
@@ -331,7 +331,7 @@
   // LISTA ENTREGADORES (legado)
   // ============================================================
   window.TrackAPI.getEntregadores = async function () {
-    const res = await req("/entregadores");
+    const res = await req("/entregadores?status=ativo");
     let data = null; try { data = await res.json(); } catch {}
     return data;
   };

--- a/Master/src/assets/js/pages/tracking-avisos.init.js
+++ b/Master/src/assets/js/pages/tracking-avisos.init.js
@@ -82,14 +82,19 @@
         .map((m) => {
           const id = Number(m.id_motoboy != null ? m.id_motoboy : m.id);
           if (!Number.isFinite(id)) return null;
+          const nomeRaw = m.nome || "Motoboy " + id;
           return {
             id,
-            nome: m.nome || "Motoboy " + id,
+            nome: (typeof window.formatPersonName === "function")
+              ? window.formatPersonName(nomeRaw)
+              : nomeRaw,
             enabled: false,
           };
         })
         .filter(Boolean)
-        .sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR", { sensitivity: "base" }));
+        .sort((a, b) => (typeof window.comparePersonNames === "function"
+          ? window.comparePersonNames(a.nome, b.nome)
+          : a.nome.localeCompare(b.nome, "pt-BR", { sensitivity: "base" })));
       renderMotoboysList();
     } catch (e) {
       motoboysState = [];

--- a/Master/src/assets/js/pages/tracking-coleta-leitura.init.js
+++ b/Master/src/assets/js/pages/tracking-coleta-leitura.init.js
@@ -697,15 +697,20 @@ document.addEventListener("DOMContentLoaded", async () => {
     const selEnt = qs("#selEntregador");
     if (selEnt && Array.isArray(entregadores)) {
       const ordenados = [...entregadores].sort((a, b) => {
-        const na = (a.nome || a.name || String(a.id_entregador ?? a.id)).trim() || String(a.id_entregador ?? a.id);
-        const nb = (b.nome || b.name || String(b.id_entregador ?? b.id)).trim() || String(b.id_entregador ?? b.id);
-        return na.localeCompare(nb, "pt-BR");
+        const naRaw = (a.nome || a.name || String(a.id_entregador ?? a.id)).trim() || String(a.id_entregador ?? a.id);
+        const nbRaw = (b.nome || b.name || String(b.id_entregador ?? b.id)).trim() || String(b.id_entregador ?? b.id);
+        const na = (typeof window.formatPersonName === "function") ? window.formatPersonName(naRaw) : naRaw;
+        const nb = (typeof window.formatPersonName === "function") ? window.formatPersonName(nbRaw) : nbRaw;
+        return (typeof window.comparePersonNames === "function")
+          ? window.comparePersonNames(na, nb)
+          : na.localeCompare(nb, "pt-BR");
       });
       selEnt.innerHTML =
         '<option value="">Usuário logado</option>' +
         ordenados.map(e => {
           const id = e.id_entregador ?? e.id;
-          const nome = (e.nome || e.name || String(id)).trim() || String(id);
+          const nomeRaw = (e.nome || e.name || String(id)).trim() || String(id);
+          const nome = (typeof window.formatPersonName === "function") ? window.formatPersonName(nomeRaw) : nomeRaw;
           return `<option value="${id}">${nome}</option>`;
         }).join("");
     }

--- a/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
@@ -879,9 +879,19 @@ document.addEventListener("DOMContentLoaded", async () => {
       const res = await fetch(`${API_ENTREGADORES}/executores?status=ativo`, { credentials: "include" });
       if (!res.ok) return;
       const list = await res.json();
-      const arr = (Array.isArray(list) ? list : []).slice().sort((a, b) => {
-        const na = String(a?.nome || a?.executor_key || "").localeCompare(String(b?.nome || b?.executor_key || ""), "pt-BR", { sensitivity: "base" });
-        if (na !== 0) return na;
+      const arr = (Array.isArray(list) ? list : []).map((e) => {
+        const nomeRaw = e?.nome || e?.executor_key || "";
+        return {
+          ...e,
+          nome: (typeof window.formatPersonName === "function")
+            ? window.formatPersonName(nomeRaw)
+            : nomeRaw,
+        };
+      }).sort((a, b) => {
+        const cmp = (typeof window.comparePersonNames === "function")
+          ? window.comparePersonNames(a?.nome, b?.nome)
+          : String(a?.nome || "").localeCompare(String(b?.nome || ""), "pt-BR", { sensitivity: "base" });
+        if (cmp !== 0) return cmp;
         return String(a?.executor_key || "").localeCompare(String(b?.executor_key || ""), "pt-BR", { sensitivity: "base" });
       });
 
@@ -890,7 +900,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       // - se houver duplicata entre entregador e motoboy, prioriza motoboy
       const byNome = new Map();
       arr.forEach((e) => {
-        const nomeKey = normalizeNomeKey(e?.nome || e?.executor_key);
+        const nomeKey = (typeof window.personNameKey === "function")
+          ? window.personNameKey(e?.nome || e?.executor_key)
+          : normalizeNomeKey(e?.nome || e?.executor_key);
         if (!nomeKey) return;
         const current = byNome.get(nomeKey);
         const incomingIsMotoboy = e?.id_motoboy != null;

--- a/Master/src/assets/js/pages/tracking-leitura.init.js
+++ b/Master/src/assets/js/pages/tracking-leitura.init.js
@@ -826,18 +826,30 @@ function createRow(row){
         .filter(e => e && (e.id_motoboy != null || e.id != null))
         .map(e => {
           const id = e.id_motoboy ?? e.id;
-          const nome = (e?.nome || e?.name || String(id)).trim() || String(id);
+          const nomeRaw = (e?.nome || e?.name || String(id)).trim() || String(id);
+          const nome = (typeof window.formatPersonName === "function")
+            ? window.formatPersonName(nomeRaw)
+            : nomeRaw;
           entregadoresMap.set(String(id), nome);
           motoboysMetaMap.set(String(id), {
             avulso_exige_foto: !!e.avulso_exige_foto,
           });
           return { id, nome };
         })
-        .sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"))
+        .sort((a, b) => (typeof window.comparePersonNames === "function"
+          ? window.comparePersonNames(a.nome, b.nome)
+          : a.nome.localeCompare(b.nome, "pt-BR")))
         .filter((item, idx, arr) => {
-          const key = normalizeNomeKey(item.nome);
+          const key = (typeof window.personNameKey === "function"
+            ? window.personNameKey(item.nome)
+            : normalizeNomeKey(item.nome));
           if (!key) return false;
-          return arr.findIndex((it) => normalizeNomeKey(it.nome) === key) === idx;
+          return arr.findIndex((it) => {
+            const k = (typeof window.personNameKey === "function"
+              ? window.personNameKey(it.nome)
+              : normalizeNomeKey(it.nome));
+            return k === key;
+          }) === idx;
         });
       if (!selEnt) return;
       selEnt.innerHTML =

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -292,26 +292,37 @@ function loadMotoboys(){
     .then(function(res) { return res.ok ? res.json() : []; })
     .then(function(data) {
       motoboysCache = Array.isArray(data) ? data : [];
-      var ordenados = motoboysCache.slice().sort(function(a, b) {
-        var na = (a.nome || "Motoboy " + (a.id_motoboy || a.id));
-        var nb = (b.nome || "Motoboy " + (b.id_motoboy || b.id));
-        return na.localeCompare(nb, "pt-BR");
-      });
+      var ordenados = (typeof window.normalizePersonList === "function"
+        ? window.normalizePersonList(motoboysCache)
+        : motoboysCache.slice().sort(function(a, b) {
+            var na = (a.nome || "Motoboy " + (a.id_motoboy || a.id));
+            var nb = (b.nome || "Motoboy " + (b.id_motoboy || b.id));
+            return na.localeCompare(nb, "pt-BR");
+          }));
       var selEdit = document.getElementById("edit-motoboy");
       var selBulk = document.getElementById("bulk-motoboy");
       var opts = '<option value="">Não alterar</option>' +
         ordenados.map(function(m) {
-          return '<option value="' + (m.id_motoboy || m.id) + '">' + (m.nome || "Motoboy " + (m.id_motoboy || m.id)) + '</option>';
+          var nome = (typeof window.formatPersonName === "function"
+            ? window.formatPersonName(m.nome || "Motoboy " + (m.id_motoboy || m.id))
+            : (m.nome || "Motoboy " + (m.id_motoboy || m.id)));
+          return '<option value="' + (m.id_motoboy || m.id) + '">' + nome + '</option>';
         }).join("");
       if (selEdit) selEdit.innerHTML = opts;
       if (selBulk) selBulk.innerHTML = '<option value="">Não alterar</option>' + ordenados.map(function(m) {
-        return '<option value="' + (m.id_motoboy || m.id) + '">' + (m.nome || "Motoboy " + (m.id_motoboy || m.id)) + '</option>';
+        var nome = (typeof window.formatPersonName === "function"
+          ? window.formatPersonName(m.nome || "Motoboy " + (m.id_motoboy || m.id))
+          : (m.nome || "Motoboy " + (m.id_motoboy || m.id)));
+        return '<option value="' + (m.id_motoboy || m.id) + '">' + nome + '</option>';
       }).join("");
       return motoboysCache;
     })
     .catch(function() { motoboysCache = []; return []; });
 }
 function buildUniqueNames(nomes){
+  if (typeof window.buildUniquePersonNames === "function") {
+    return window.buildUniquePersonNames(nomes);
+  }
   var map = new Map();
   (nomes || []).forEach(function(n){
     var display = String(n || "").trim();
@@ -339,12 +350,11 @@ function fillEntregadores(nomes){
 
 }
 function augmentEntregadoresFromRows(rows){
-  var nomesLista = (rows || [])
-    .map(r => r?.entregador)
-    .filter(Boolean);
-  var unicos = buildUniqueNames((augmentEntregadoresFromRows._base || []).concat(nomesLista));
-  augmentEntregadoresFromRows._base = unicos;
-  fillEntregadores(unicos);
+  // Não reintroduz no filtro nomes só presentes em histórico (ex.: usuário já excluído).
+  // A base operacional vem de entregadores/motoboys ativos carregados no init.
+  var base = augmentEntregadoresFromRows._base || [];
+  if (!base.length) return;
+  fillEntregadores(base);
 }
 
 
@@ -2532,7 +2542,10 @@ function setupPagerEvents() {
     .then(function(results) {
       var nomesEntregadores = results[0] || [];
       var motoboys = results[1] || [];
-      var nomesMotoboys = motoboys.map(function(m) { return (m.nome || ("Motoboy " + (m.id_motoboy || m.id))); });
+      var nomesMotoboys = motoboys.map(function(m) {
+        var raw = (m.nome || ("Motoboy " + (m.id_motoboy || m.id)));
+        return (typeof window.formatPersonName === "function") ? window.formatPersonName(raw) : raw;
+      });
       var todos = (nomesEntregadores).concat(nomesMotoboys);
       var unicos = buildUniqueNames(todos);
       augmentEntregadoresFromRows._base = unicos;

--- a/Master/src/assets/js/pages/tracking-usuarios.js
+++ b/Master/src/assets/js/pages/tracking-usuarios.js
@@ -351,17 +351,27 @@ function applyFilters() {
         );
     });
 
-    // Ordenar por nome (asc) e, em seguida, sobrenome
+    // Ordenar por nome (asc) e, em seguida, sobrenome — padrão pt-BR
     FILTERED.sort((a, b) => {
-        const nomeA = (a.nome || "").toLowerCase();
-        const nomeB = (b.nome || "").toLowerCase();
-        if (nomeA < nomeB) return -1;
-        if (nomeA > nomeB) return 1;
-        const sobA = (a.sobrenome || "").toLowerCase();
-        const sobB = (b.sobrenome || "").toLowerCase();
-        if (sobA < sobB) return -1;
-        if (sobA > sobB) return 1;
-        return 0;
+        const nomeA = (typeof window.formatPersonName === "function")
+          ? window.formatPersonName(a.nome || "")
+          : (a.nome || "");
+        const nomeB = (typeof window.formatPersonName === "function")
+          ? window.formatPersonName(b.nome || "")
+          : (b.nome || "");
+        const cmpNome = (typeof window.comparePersonNames === "function")
+          ? window.comparePersonNames(nomeA, nomeB)
+          : nomeA.localeCompare(nomeB, "pt-BR", { sensitivity: "base" });
+        if (cmpNome !== 0) return cmpNome;
+        const sobA = (typeof window.formatPersonName === "function")
+          ? window.formatPersonName(a.sobrenome || "")
+          : (a.sobrenome || "");
+        const sobB = (typeof window.formatPersonName === "function")
+          ? window.formatPersonName(b.sobrenome || "")
+          : (b.sobrenome || "");
+        return (typeof window.comparePersonNames === "function")
+          ? window.comparePersonNames(sobA, sobB)
+          : sobA.localeCompare(sobB, "pt-BR", { sensitivity: "base" });
     });
 
     CURRENT_PAGE = 1;
@@ -402,8 +412,8 @@ function renderTable() {
         return `
         <tr data-id="${u.id}" data-role="${u.role || 0}">
             <td><input class="form-check-input row-select" type="checkbox"></td>
-            <td>${u.nome || "-"}</td>
-            <td>${u.sobrenome || "-"}</td>
+            <td>${(typeof window.formatPersonName === "function" ? window.formatPersonName(u.nome || "") : (u.nome || "")) || "-"}</td>
+            <td>${(typeof window.formatPersonName === "function" ? window.formatPersonName(u.sobrenome || "") : (u.sobrenome || "")) || "-"}</td>
             <td>${u.username}</td>
             <td>${u.email}</td>
            <td>
@@ -901,19 +911,36 @@ function deleteFromSelection() {
 
 async function deleteUsers(ids) {
     try {
+        const falhas = [];
         for (const id of ids) {
-            await fetch(`${API}/${id}`, {
+            const resp = await fetch(`${API}/${id}`, {
                 method: "DELETE",
                 credentials: "include"
             });
+            if (!resp.ok) {
+                let detail = "";
+                try {
+                    const body = await resp.json();
+                    detail = body?.detail || body?.message || "";
+                } catch (_) {}
+                falhas.push(`${id}${detail ? ` (${detail})` : ""}`);
+            }
         }
 
-        Swal.fire({
-            icon: "success",
-            title: "Excluído!",
-            timer: 1000,
-            showConfirmButton: false
-        });
+        if (falhas.length) {
+            Swal.fire({
+                icon: "error",
+                title: "Falha ao excluir",
+                text: `Não foi possível excluir: ${falhas.join(", ")}`
+            });
+        } else {
+            Swal.fire({
+                icon: "success",
+                title: "Excluído!",
+                timer: 1000,
+                showConfirmButton: false
+            });
+        }
 
         loadUsers();
 

--- a/Master/src/assets/js/pages/tracking-valores-entrega.init.js
+++ b/Master/src/assets/js/pages/tracking-valores-entrega.init.js
@@ -200,14 +200,19 @@
         const id = Number(e?.executor_id ?? e?.motoboy_id);
         if (!Number.isFinite(id) || id <= 0) return;
         if (idsComExcecao.has(id)) return;
-        const nome = String(e?.nome || id).trim();
+        const nomeRaw = String(e?.nome || id).trim();
+        const nome = (typeof window.formatPersonName === "function")
+          ? window.formatPersonName(nomeRaw)
+          : nomeRaw;
         const key = String(id);
         if (!unicos.has(key)) {
           unicos.set(key, { id_motoboy: id, nome });
         }
       });
       const ordenados = Array.from(unicos.values())
-        .sort((a, b) => String(a?.nome || a?.id_motoboy || "").localeCompare(String(b?.nome || b?.id_motoboy || ""), "pt-BR", { sensitivity: "base" }));
+        .sort((a, b) => (typeof window.comparePersonNames === "function"
+          ? window.comparePersonNames(a?.nome, b?.nome)
+          : String(a?.nome || a?.id_motoboy || "").localeCompare(String(b?.nome || b?.id_motoboy || ""), "pt-BR", { sensitivity: "base" })));
       select.innerHTML = '<option value="">Selecione o motoboy</option>' +
         ordenados
           .map((e) => `<option value="${e.id_motoboy}">${e.nome || e.id_motoboy}</option>`)

--- a/Master/src/assets/js/person-name.js
+++ b/Master/src/assets/js/person-name.js
@@ -1,0 +1,102 @@
+/**
+ * Padrão do sistema para nomes de pessoas (web).
+ * - Inicial maiúscula, restante minúsculo por palavra
+ * - Partículas pt-BR (de/da/do/das/dos/e) em minúsculo (exceto 1ª palavra)
+ * - Ordenação alfabética pt-BR
+ */
+(function (global) {
+  "use strict";
+
+  var MINOR_WORDS = { de: 1, da: 1, do: 1, das: 1, dos: 1, e: 1 };
+
+  function formatPersonName(raw) {
+    var s = String(raw || "").replace(/\s+/g, " ").trim();
+    if (!s) return "";
+    return s
+      .split(" ")
+      .map(function (word, index) {
+        var lower = word.toLocaleLowerCase("pt-BR");
+        if (index > 0 && MINOR_WORDS[lower]) return lower;
+        return lower
+          .split("-")
+          .map(function (chunk) {
+            if (!chunk) return chunk;
+            return chunk.charAt(0).toLocaleUpperCase("pt-BR") + chunk.slice(1);
+          })
+          .join("-");
+      })
+      .join(" ");
+  }
+
+  function personNameKey(raw) {
+    return String(raw || "")
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLocaleLowerCase("pt-BR")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function comparePersonNames(a, b) {
+    return String(a || "").localeCompare(String(b || ""), "pt-BR", { sensitivity: "base" });
+  }
+
+  function sortByPersonName(list, getName) {
+    var getter =
+      typeof getName === "function"
+        ? getName
+        : function (item) {
+            if (item == null) return "";
+            if (typeof item === "string") return item;
+            return item.nome || item.name || item.motoboy_nome || item.entregador_nome || "";
+          };
+    return (list || []).slice().sort(function (a, b) {
+      return comparePersonNames(getter(a), getter(b));
+    });
+  }
+
+  /** Formata nome de cada item e ordena A→Z. */
+  function normalizePersonList(list, getName, setName) {
+    var getter =
+      typeof getName === "function"
+        ? getName
+        : function (item) {
+            return item && (item.nome || item.name || "");
+          };
+    var setter =
+      typeof setName === "function"
+        ? setName
+        : function (item, nome) {
+            if (item && typeof item === "object") item.nome = nome;
+            return item;
+          };
+    var mapped = (list || []).map(function (item) {
+      if (typeof item === "string") return formatPersonName(item);
+      var copy = Object.assign({}, item);
+      setter(copy, formatPersonName(getter(item)));
+      return copy;
+    });
+    return sortByPersonName(mapped, getter);
+  }
+
+  function buildUniquePersonNames(nomes) {
+    var map = new Map();
+    (nomes || []).forEach(function (n) {
+      var display = formatPersonName(n);
+      if (!display) return;
+      var key = personNameKey(display);
+      if (!map.has(key)) map.set(key, display);
+    });
+    return Array.from(map.values()).sort(comparePersonNames);
+  }
+
+  global.formatPersonName = formatPersonName;
+  global.personNameKey = personNameKey;
+  global.comparePersonNames = comparePersonNames;
+  global.sortByPersonName = sortByPersonName;
+  global.normalizePersonList = normalizePersonList;
+  global.buildUniquePersonNames = buildUniquePersonNames;
+
+  // Alias legado usado em várias telas
+  global.normalizeNomeKey = personNameKey;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/Master/src/partials/vendor-scripts.html
+++ b/Master/src/partials/vendor-scripts.html
@@ -5,6 +5,7 @@
 <script src="assets/libs/feather-icons/feather.min.js"></script>
 <script src="assets/js/pages/plugins/lord-icon-2.1.0.js"></script>
 <script src="assets/js/plugins.js"></script>
+<script src="assets/js/person-name.js"></script>
 <script src="assets/libs/sweetalert2/sweetalert2.min.js"></script>
 <script src="/assets/vendor/zxing/zxing.bundle.min.js"></script>
 <script src="assets/js/pages/owner-labels.init.js"></script>


### PR DESCRIPTION
## Resumo

Ajusta filtros e telas web para não reexibir usuários excluídos e aplica o padrão de nomes (Title Case + ordem alfabética) em selects/listagens operacionais.

## Tipo de alteração

- [x] fix
- [ ] feature
- [ ] bug
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- `getEntregadores` passa a usar `?status=ativo`
- Exclusão de usuários valida HTTP antes de confirmar sucesso
- Filtro de Registros não reintroduz nomes só do histórico
- Novo `person-name.js` global e aplicação nas telas: Usuários, Leitura, Registros, Acompanhamento, Avisos, Valores, Fechamento e Coleta

## Como testar

- Excluir usuário no cadastro e conferir que some dos filtros de Registros/Fechamento
- Abrir selects de motoboy/entregador e validar nomes normalizados e ordenados A→Z
- Confirmar que falha de exclusão (API) não mostra “Excluído!”

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Rollback

Reverter este PR / branch `fix/usuarios-excluidos-filtros`.

Made with [Cursor](https://cursor.com)