### PR TITLE
feat: KPIs de entrada, layout full width e pódio no indicador de saídas

### DIFF
--- a/Master/src/assets/js/pages/dashboard-saidas.init.js
+++ b/Master/src/assets/js/pages/dashboard-saidas.init.js
@@ -7,6 +7,8 @@
   "use strict";
 
   const API_BASE = (window.TRACK_API_URL || "").replace(/\/+$/, "");
+  const COLORS = { shopee: "#ee4d2d", mercado_livre: "#ffe600", avulso: "#6c757d" };
+  const PODIUM_MEDALS = ["#c9a227", "#9aa0a6", "#b87333"]; // 1º ouro, 2º prata, 3º bronze
 
   function fmtYMD(d) {
     const mm = String(d.getMonth() + 1).padStart(2, "0");
@@ -67,6 +69,12 @@
     return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(v || 0);
   }
 
+  function formatGap(n) {
+    const v = Number(n) || 0;
+    if (v > 0) return "+" + v;
+    return String(v);
+  }
+
   function loadDashboard(from, to) {
     const params = new URLSearchParams();
     if (from) params.set("data_inicio", from);
@@ -86,7 +94,6 @@
 
   function renderCardsMarketplace(data) {
     const items = data.por_marketplace || [];
-    const total = (data.cards || {}).total_saidas || 1;
     const shopee = items.find(function (x) { return x.nome === "Shopee"; });
     const ml = items.find(function (x) { return x.nome === "Mercado Livre"; });
     const avulso = items.find(function (x) { return x.nome === "Avulso"; });
@@ -98,6 +105,41 @@
       setText("card-marketplace-" + prefix + "-pct", pct + "% do total");
       setText("card-marketplace-" + prefix + "-valor", formatMoeda(item.valor));
       const bar = document.getElementById("bar-marketplace-" + prefix);
+      if (bar) bar.style.width = pct + "%";
+    }
+    renderOne(shopee, "shopee");
+    renderOne(ml, "ml");
+    renderOne(avulso, "avulso");
+  }
+
+  function renderEntrada(data) {
+    const section = document.getElementById("saidas-entrada-section");
+    const subtitle = document.getElementById("saidas-evolucao-subtitle");
+    const enabled = !!(data && data.entrada_habilitada && data.entrada);
+    if (section) section.classList.toggle("d-none", !enabled);
+    if (subtitle) {
+      subtitle.textContent = enabled
+        ? "Volume por serviço, entradas e custo acumulado"
+        : "Volume por serviço e custo acumulado";
+    }
+    if (!enabled) return;
+
+    const e = data.entrada;
+    setText("card-total-entradas", e.total_entradas ?? 0);
+    setText("card-ainda-na-base", e.ainda_na_base ?? 0);
+    setText("card-taxa-saida", (e.taxa_saida_pct ?? 0) + "%");
+    setText("card-gap-entrada-saida", formatGap(e.gap_entrada_saida));
+
+    const items = e.por_marketplace || [];
+    const shopee = items.find(function (x) { return x.nome === "Shopee"; });
+    const ml = items.find(function (x) { return x.nome === "Mercado Livre"; });
+    const avulso = items.find(function (x) { return x.nome === "Avulso"; });
+
+    function renderOne(item, prefix) {
+      const pct = item ? (item.pct ?? 0) : 0;
+      setText("card-entrada-" + prefix + "-qty", item ? (item.qty ?? 0) : 0);
+      setText("card-entrada-" + prefix + "-pct", pct + "% do total");
+      const bar = document.getElementById("bar-entrada-" + prefix);
       if (bar) bar.style.width = pct + "%";
     }
     renderOne(shopee, "shopee");
@@ -118,6 +160,7 @@
     const el = document.getElementById("chart-evolucao-saidas");
     if (!el || typeof echarts === "undefined") return;
 
+    const showEntradas = !!(data && data.entrada_habilitada);
     const dates = items.map(function (x) {
       const d = x.date || "";
       return d.length >= 10 ? d.substr(8, 2) + "/" + d.substr(5, 2) : d;
@@ -125,6 +168,10 @@
     const shopee = items.map(function (x) { return x.shopee || 0; });
     const ml = items.map(function (x) { return x.mercado_livre || 0; });
     const avulso = items.map(function (x) { return x.avulso || 0; });
+    const entradas = items.map(function (x) { return x.entradas || 0; });
+    const saidasDia = items.map(function (x) {
+      return (x.shopee || 0) + (x.mercado_livre || 0) + (x.avulso || 0);
+    });
     const valorTotal = items.map(function (x) {
       const v = x.valor_total;
       return typeof v === "number" ? v : (parseFloat(String(v || 0).replace(",", ".")) || 0);
@@ -133,6 +180,8 @@
     const totShopee = shopee.reduce(function (a, b) { return a + b; }, 0);
     const totMl = ml.reduce(function (a, b) { return a + b; }, 0);
     const totAvulso = avulso.reduce(function (a, b) { return a + b; }, 0);
+    const totEntradas = entradas.reduce(function (a, b) { return a + b; }, 0);
+    const totSaidas = saidasDia.reduce(function (a, b) { return a + b; }, 0);
 
     var chart = echarts.getInstanceByDom(el);
     if (!chart) chart = echarts.init(el);
@@ -157,9 +206,42 @@
       { name: "Valor (R$)", type: "line", yAxisIndex: 1, data: valorTotal, symbol: "circle", symbolSize: 6, lineStyle: { type: "solid", width: 2 }, itemStyle: { color: "#0d6efd" }, tooltip: { valueFormatter: function (v) { return formatMoeda(Number(v) || 0); } } }
     ];
 
+    if (showEntradas) {
+      series.splice(3, 0,
+        {
+          name: "Entradas",
+          type: "line",
+          data: entradas,
+          symbol: "diamond",
+          symbolSize: 7,
+          lineStyle: { width: 2, type: "dashed" },
+          itemStyle: { color: "#495057" },
+        },
+        {
+          name: "Saídas",
+          type: "line",
+          data: saidasDia,
+          symbol: "circle",
+          symbolSize: 6,
+          lineStyle: { width: 2 },
+          itemStyle: { color: "#198754" },
+        }
+      );
+    }
+
+    var legendNames = series.map(function (s) { return s.name; });
+
     var opt = {
       tooltip: { trigger: "axis", formatter: tooltipFormatter },
-      legend: { data: ["Shopee (" + totShopee + ")", "Mercado Livre (" + totMl + ")", "Avulso (" + totAvulso + ")", "Valor (R$)"] },
+      legend: { data: legendNames, formatter: function (name) {
+        if (name === "Shopee") return "Shopee (" + totShopee + ")";
+        if (name === "Mercado Livre") return "Mercado Livre (" + totMl + ")";
+        if (name === "Avulso") return "Avulso (" + totAvulso + ")";
+        if (name === "Entradas") return "Entradas (" + totEntradas + ")";
+        if (name === "Saídas") return "Saídas (" + totSaidas + ")";
+        return name;
+      } },
+      grid: { left: 48, right: 56, top: 48, bottom: 32 },
       xAxis: { type: "category", data: dates },
       yAxis: [
         { type: "value", name: "Qtd" },
@@ -174,43 +256,118 @@
     }
   }
 
+  function serviceBadges(r) {
+    var labels = [];
+    if ((r.shopee || 0) > 0) labels.push("<span class='badge me-1' style='background:" + COLORS.shopee + ";color:#fff'>Shopee: " + r.shopee + "</span>");
+    if ((r.mercado_livre || 0) > 0) labels.push("<span class='badge me-1' style='background:" + COLORS.mercado_livre + ";color:#333'>ML: " + r.mercado_livre + "</span>");
+    if ((r.avulso || 0) > 0) labels.push("<span class='badge me-1' style='background:" + COLORS.avulso + ";color:#fff'>Avulso: " + r.avulso + "</span>");
+    return labels.join("") || "<span class='text-muted'>—</span>";
+  }
+
+  function serviceBar(r) {
+    const total = (r.shopee || 0) + (r.mercado_livre || 0) + (r.avulso || 0) || 1;
+    const pShopee = total > 0 ? Math.round((r.shopee || 0) / total * 100) : 0;
+    const pMl = total > 0 ? Math.round((r.mercado_livre || 0) / total * 100) : 0;
+    const pAvulso = total > 0 ? Math.round((r.avulso || 0) / total * 100) : 0;
+    var barParts = [];
+    if (pShopee > 0) barParts.push("<div style='width:" + pShopee + "%;background:" + COLORS.shopee + ";height:100%'></div>");
+    if (pMl > 0) barParts.push("<div style='width:" + pMl + "%;background:" + COLORS.mercado_livre + ";height:100%'></div>");
+    if (pAvulso > 0) barParts.push("<div style='width:" + pAvulso + "%;background:" + COLORS.avulso + ";height:100%'></div>");
+    return "<div class='d-flex rounded' style='height:8px;overflow:hidden;background:rgba(0,0,0,.06)'>" + barParts.join("") + "</div>";
+  }
+
+  function renderRankingList(items, startPlace, leaderVolume) {
+    const offset = typeof startPlace === "number" ? startPlace : 1;
+    const maxFromItems = Math.max.apply(null, items.map(function (x) { return x.volume || 0; }).concat([0])) || 1;
+    const leaderVol = leaderVolume || maxFromItems;
+    return items.map(function (r, i) {
+      return (
+        "<div class='row align-items-center g-3 py-3 border-bottom border-light'>" +
+          "<div class='col-auto'>" +
+            "<span class='badge rounded-pill' style='min-width:28px;background:rgba(0,0,0,.08);color:#333;font-size:13px'>" + (offset + i) + "</span>" +
+          "</div>" +
+          "<div class='col-md-4 col-lg-5 min-w-0'>" +
+            "<div class='fw-semibold text-truncate' title='" + escapeHtml(r.nome) + "'>" + escapeHtml(r.nome) + "</div>" +
+            "<div class='d-flex flex-wrap gap-1 mt-1'>" + serviceBadges(r) + "</div>" +
+          "</div>" +
+          "<div class='col-md-3 col-lg-3'>" + serviceBar(r) + "</div>" +
+          "<div class='col-auto ms-md-auto text-end'>" +
+            "<div class='fw-bold text-primary fs-5'>" + (r.volume || 0) + "</div>" +
+            "<small class='text-muted'>" + formatMoeda(r.custo) + "</small>" +
+            "<div class='text-muted' style='font-size:11px'>" + Math.round(((r.volume || 0) / leaderVol) * 100) + "% do líder</div>" +
+          "</div>" +
+        "</div>"
+      );
+    }).join("");
+  }
+
+  function renderPodium(items) {
+    const top = items.slice(0, 3);
+    const rest = items.slice(3);
+    const leaderVol = (items[0] && items[0].volume) || 1;
+    // Ordem visual: 2º | 1º | 3º
+    const order = [];
+    if (top[1]) order.push({ item: top[1], place: 2 });
+    if (top[0]) order.push({ item: top[0], place: 1 });
+    if (top[2]) order.push({ item: top[2], place: 3 });
+
+    var html = "<div class='row g-3 align-items-stretch mb-3 justify-content-center'>";
+    order.forEach(function (entry) {
+      const r = entry.item;
+      const place = entry.place;
+      const isFirst = place === 1;
+      const medal = PODIUM_MEDALS[place - 1];
+      html +=
+        "<div class='col-md-4'>" +
+          "<div class='card h-100 border-0 shadow-sm' style='border-top:4px solid " + medal + " !important'>" +
+            "<div class='card-body text-center " + (isFirst ? "py-4" : "py-3") + "'>" +
+              "<div class='rounded-circle d-inline-flex align-items-center justify-content-center mb-2' style='width:" + (isFirst ? 48 : 40) + "px;height:" + (isFirst ? 48 : 40) + "px;background:" + medal + ";color:#fff;font-weight:800'>" + place + "</div>" +
+              "<div class='fw-semibold mb-1' style='font-size:" + (isFirst ? "16px" : "14px") + "'>" + escapeHtml(r.nome) + "</div>" +
+              "<div class='fw-bold text-primary' style='font-size:" + (isFirst ? "28px" : "22px") + "'>" + (r.volume || 0) + "</div>" +
+              "<div class='text-muted mb-2'>" + formatMoeda(r.custo) + "</div>" +
+              "<div class='d-flex flex-wrap justify-content-center gap-1 mb-2'>" + serviceBadges(r) + "</div>" +
+              serviceBar(r) +
+            "</div>" +
+          "</div>" +
+        "</div>";
+    });
+    html += "</div>";
+
+    if (rest.length) {
+      html +=
+        "<div class='mt-2'>" +
+          "<div class='text-muted small mb-2 fw-semibold text-uppercase'>Demais entregadores</div>" +
+          renderRankingList(rest, 4, leaderVol) +
+        "</div>";
+    }
+    return html;
+  }
+
   function renderRankingEntregadores(data) {
-    const items = data.ranking_entregadores || [];
+    const items = (data.ranking_entregadores || []).slice(0, 15);
     const container = document.getElementById("ranking-entregadores-saidas");
     if (!container) return;
     if (items.length === 0) {
-      container.innerHTML = "<p class='text-muted mb-0'>Sem dados</p>";
+      container.innerHTML = "<p class='text-muted mb-0'>Sem dados no período</p>";
       return;
     }
-    const maxVolume = Math.max.apply(null, items.map(function (x) { return x.volume || 0; })) || 1;
-    const COLORS = { shopee: "#ee4d2d", mercado_livre: "#ffe600", avulso: "#6c757d" };
-    container.innerHTML = items.slice(0, 10).map(function (r, i) {
-      const total = (r.shopee || 0) + (r.mercado_livre || 0) + (r.avulso || 0) || 1;
-      const pShopee = total > 0 ? Math.round((r.shopee || 0) / total * 100) : 0;
-      const pMl = total > 0 ? Math.round((r.mercado_livre || 0) / total * 100) : 0;
-      const pAvulso = total > 0 ? Math.round((r.avulso || 0) / total * 100) : 0;
-      const pctTotal = Math.round((r.volume || 0) / maxVolume * 100);
-      var labels = [];
-      if ((r.shopee || 0) > 0) labels.push("<span class='badge me-1' style='background:" + COLORS.shopee + ";color:#fff'>Shopee: " + r.shopee + "</span>");
-      if ((r.mercado_livre || 0) > 0) labels.push("<span class='badge me-1' style='background:" + COLORS.mercado_livre + ";color:#333'>ML: " + r.mercado_livre + "</span>");
-      if ((r.avulso || 0) > 0) labels.push("<span class='badge me-1' style='background:" + COLORS.avulso + ";color:#fff'>Avulso: " + r.avulso + "</span>");
-      var barParts = [];
-      if (pShopee > 0) barParts.push("<div style='width:" + pShopee + "%;background:" + COLORS.shopee + ";height:100%'></div>");
-      if (pMl > 0) barParts.push("<div style='width:" + pMl + "%;background:" + COLORS.mercado_livre + ";height:100%'></div>");
-      if (pAvulso > 0) barParts.push("<div style='width:" + pAvulso + "%;background:" + COLORS.avulso + ";height:100%'></div>");
-      return "<div class='py-2 border-bottom border-light'>" +
-        "<div class='d-flex align-items-center justify-content-between mb-1'>" +
-        "<span class='badge rounded-pill me-2' style='min-width:24px;background:rgba(0,0,0,.08);color:#333'>" + (i + 1) + "</span>" +
-        "<strong class='flex-grow-1'>" + escapeHtml(r.nome) + "</strong>" +
-        "<div class='text-end'>" +
-        "<div class='fw-bold text-primary'>" + r.volume + "</div>" +
-        "<small class='text-muted'>" + formatMoeda(r.custo) + "</small>" +
-        "</div>" +
-        "</div>" +
-        "<div class='d-flex flex-wrap gap-1 mb-1'>" + (labels.join("") || "-") + "</div>" +
-        "<div class='d-flex rounded' style='height:6px;overflow:hidden;background:rgba(0,0,0,.06)'>" + barParts.join("") + "</div>" +
-        "</div>";
-    }).join("");
+    const view = (window.TrackPrefs && window.TrackPrefs.getIndicadorRankingView && window.TrackPrefs.getIndicadorRankingView()) || "podio";
+    if (view === "podio") {
+      container.innerHTML = renderPodium(items);
+    } else {
+      container.innerHTML = renderRankingList(items);
+    }
+  }
+
+  function syncRankingViewToggleUI() {
+    var view = (window.TrackPrefs && window.TrackPrefs.getIndicadorRankingView && window.TrackPrefs.getIndicadorRankingView()) || "podio";
+    var group = document.getElementById("saidas-ranking-view-group");
+    if (!group) return;
+    group.querySelectorAll("button[data-ranking-view]").forEach(function (b) {
+      var isActive = b.getAttribute("data-ranking-view") === view;
+      b.classList.toggle("btn-primary", isActive);
+      b.classList.toggle("btn-outline-secondary", !isActive);
+    });
   }
 
   function showAcessoNegado() {
@@ -269,6 +426,8 @@
       });
     }
     syncSaidasIndicadorToggleUI();
+    syncRankingViewToggleUI();
+
     var saidasModeGroup = document.getElementById("saidas-indicador-status-mode-group");
     if (saidasModeGroup) {
       saidasModeGroup.addEventListener("click", function (ev) {
@@ -279,6 +438,19 @@
         if (window.TrackPrefs && window.TrackPrefs.setIndicadorStatusMode) window.TrackPrefs.setIndicadorStatusMode(mode);
         syncSaidasIndicadorToggleUI();
         load();
+      });
+    }
+
+    var rankingViewGroup = document.getElementById("saidas-ranking-view-group");
+    if (rankingViewGroup) {
+      rankingViewGroup.addEventListener("click", function (ev) {
+        var btn = ev.target && ev.target.closest && ev.target.closest("button[data-ranking-view]");
+        if (!btn) return;
+        var view = btn.getAttribute("data-ranking-view");
+        if (view !== "podio" && view !== "ranking") return;
+        if (window.TrackPrefs && window.TrackPrefs.setIndicadorRankingView) window.TrackPrefs.setIndicadorRankingView(view);
+        syncRankingViewToggleUI();
+        if (window._saidasDashData) renderRankingEntregadores(window._saidasDashData);
       });
     }
 
@@ -294,6 +466,7 @@
       try {
         const data = await loadDashboard(from, to);
         renderCards(data);
+        renderEntrada(data);
         renderCardsMarketplace(data);
         renderCancelamentos(data);
         renderChartEvolucao(data);

--- a/Master/src/assets/js/user-preferences.js
+++ b/Master/src/assets/js/user-preferences.js
@@ -7,6 +7,8 @@
 
   const STORAGE_KEY = "track_indicadores_status_mode";
   const VALID_MODES = ["saiu", "operacional", "entregue"];
+  const RANKING_VIEW_KEY = "track_indicadores_ranking_view";
+  const VALID_RANKING_VIEWS = ["podio", "ranking"];
 
   function getIndicadorStatusMode() {
     try {
@@ -27,8 +29,27 @@
     } catch (_) {}
   }
 
+  function getIndicadorRankingView() {
+    try {
+      const raw = (localStorage.getItem(RANKING_VIEW_KEY) || "podio").trim().toLowerCase();
+      return VALID_RANKING_VIEWS.includes(raw) ? raw : "podio";
+    } catch (_) {
+      return "podio";
+    }
+  }
+
+  function setIndicadorRankingView(view) {
+    const v = (view || "podio").trim().toLowerCase();
+    if (!VALID_RANKING_VIEWS.includes(v)) return;
+    try {
+      localStorage.setItem(RANKING_VIEW_KEY, v);
+    } catch (_) {}
+  }
+
   window.TrackPrefs = {
     getIndicadorStatusMode: getIndicadorStatusMode,
     setIndicadorStatusMode: setIndicadorStatusMode,
+    getIndicadorRankingView: getIndicadorRankingView,
+    setIndicadorRankingView: setIndicadorRankingView,
   };
 })();

--- a/Master/src/dashboard-saidas.html
+++ b/Master/src/dashboard-saidas.html
@@ -114,7 +114,111 @@
               </div>
             </section>
 
-            <!-- Cards por marketplace -->
+            <!-- Entrada na base × saídas (somente se owner registra entrada) -->
+            <section id="saidas-entrada-section" class="mb-4 d-none">
+              <div class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2">
+                <div>
+                  <h5 class="mb-0 fs-16">Entrada na base × saídas</h5>
+                  <small class="text-muted">Quanto entrou, o que ainda está na base e a proporção com as saídas</small>
+                </div>
+              </div>
+              <div class="row g-3 mb-3">
+                <div class="col-6 col-xl-3">
+                  <div class="card card-height-100 border border-secondary">
+                    <div class="card-body d-flex align-items-center">
+                      <div class="flex-grow-1">
+                        <p class="text-muted mb-1">Total de Entradas</p>
+                        <h4 class="mb-0"><span id="card-total-entradas">0</span></h4>
+                        <small class="text-muted">Pacotes no período</small>
+                      </div>
+                      <i class="bx bx-log-in-circle fs-2 text-secondary"></i>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-6 col-xl-3">
+                  <div class="card card-height-100 border border-dark">
+                    <div class="card-body d-flex align-items-center">
+                      <div class="flex-grow-1">
+                        <p class="text-muted mb-1">Ainda na base</p>
+                        <h4 class="mb-0"><span id="card-ainda-na-base">0</span></h4>
+                        <small class="text-muted">Aguardando saída</small>
+                      </div>
+                      <i class="bx bx-home-alt fs-2 text-dark"></i>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-6 col-xl-3">
+                  <div class="card card-height-100 border border-primary">
+                    <div class="card-body d-flex align-items-center">
+                      <div class="flex-grow-1">
+                        <p class="text-muted mb-1">Taxa de saída</p>
+                        <h4 class="mb-0"><span id="card-taxa-saida">0%</span></h4>
+                        <small class="text-muted">Saídas ÷ entradas</small>
+                      </div>
+                      <i class="bx bx-pie-chart-alt-2 fs-2 text-primary"></i>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-6 col-xl-3">
+                  <div class="card card-height-100 border border-warning">
+                    <div class="card-body d-flex align-items-center">
+                      <div class="flex-grow-1">
+                        <p class="text-muted mb-1">Gap (entrou − saiu)</p>
+                        <h4 class="mb-0"><span id="card-gap-entrada-saida">0</span></h4>
+                        <small class="text-muted">Diferença no período</small>
+                      </div>
+                      <i class="bx bx-git-compare fs-2 text-warning"></i>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="row g-3">
+                <div class="col-md-4">
+                  <div class="card border overflow-hidden" style="border-color: rgba(238,77,45,0.5) !important; border-left: 4px solid #ee4d2d !important;">
+                    <div class="card-body">
+                      <h6 class="card-title text-uppercase mb-2">Entradas · Shopee</h6>
+                      <div class="d-flex justify-content-between align-items-baseline mb-1">
+                        <span class="fs-4 fw-bold" id="card-entrada-shopee-qty">0</span>
+                        <span class="text-muted small" id="card-entrada-shopee-pct">0% do total</span>
+                      </div>
+                      <div class="progress" style="height: 6px;">
+                        <div class="progress-bar" style="background-color: #ee4d2d; width: 0%;" id="bar-entrada-shopee"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-4">
+                  <div class="card border overflow-hidden" style="border-color: rgba(255,230,0,0.6) !important; border-left: 4px solid #ffe600 !important;">
+                    <div class="card-body">
+                      <h6 class="card-title text-uppercase mb-2">Entradas · Mercado Livre</h6>
+                      <div class="d-flex justify-content-between align-items-baseline mb-1">
+                        <span class="fs-4 fw-bold" id="card-entrada-ml-qty">0</span>
+                        <span class="text-muted small" id="card-entrada-ml-pct">0% do total</span>
+                      </div>
+                      <div class="progress" style="height: 6px;">
+                        <div class="progress-bar" style="background-color: #ffe600; width: 0%;" id="bar-entrada-ml"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-4">
+                  <div class="card border overflow-hidden" style="border-color: rgba(108,117,125,0.5) !important; border-left: 4px solid #6c757d !important;">
+                    <div class="card-body">
+                      <h6 class="card-title text-uppercase mb-2">Entradas · Avulso</h6>
+                      <div class="d-flex justify-content-between align-items-baseline mb-1">
+                        <span class="fs-4 fw-bold" id="card-entrada-avulso-qty">0</span>
+                        <span class="text-muted small" id="card-entrada-avulso-pct">0% do total</span>
+                      </div>
+                      <div class="progress" style="height: 6px;">
+                        <div class="progress-bar" style="background-color: #6c757d; width: 0%;" id="bar-entrada-avulso"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <!-- Cards por marketplace (saídas) -->
             <section class="mb-4">
               <div class="row g-3">
                 <div class="col-md-4">
@@ -179,38 +283,44 @@
               </div>
             </section>
 
-            <!-- Evolução Diária + Ranking Entregadores -->
-            <div class="row g-4">
-              <div class="col-lg-8">
-                <div class="card">
-                  <div class="card-header d-flex align-items-center justify-content-between gap-2 flex-wrap">
-                    <div>
-                      <h5 class="card-title mb-0">Evolução Diária</h5>
-                      <small class="text-muted">Volume por serviço e custo acumulado</small>
-                    </div>
-                    <div class="btn-group btn-group-sm" role="group">
-                      <button type="button" class="btn btn-outline-primary active" data-chart-type="bar" title="Barras"><i class="bx bx-bar-chart-alt"></i></button>
-                      <button type="button" class="btn btn-outline-primary" data-chart-type="line" title="Linha"><i class="bx bx-line-chart"></i></button>
-                      <button type="button" class="btn btn-outline-primary" data-chart-type="area" title="Área"><i class="bx bx-area"></i></button>
-                    </div>
+            <!-- Evolução Diária (largura total) -->
+            <section class="mb-4">
+              <div class="card">
+                <div class="card-header d-flex align-items-center justify-content-between gap-2 flex-wrap">
+                  <div>
+                    <h5 class="card-title mb-0">Evolução Diária</h5>
+                    <small class="text-muted" id="saidas-evolucao-subtitle">Volume por serviço e custo acumulado</small>
                   </div>
-                  <div class="card-body">
-                    <div id="chart-evolucao-saidas" style="height: 280px;"></div>
+                  <div class="btn-group btn-group-sm" role="group">
+                    <button type="button" class="btn btn-outline-primary active" data-chart-type="bar" title="Barras"><i class="bx bx-bar-chart-alt"></i></button>
+                    <button type="button" class="btn btn-outline-primary" data-chart-type="line" title="Linha"><i class="bx bx-line-chart"></i></button>
+                    <button type="button" class="btn btn-outline-primary" data-chart-type="area" title="Área"><i class="bx bx-area"></i></button>
                   </div>
                 </div>
+                <div class="card-body">
+                  <div id="chart-evolucao-saidas" style="height: 320px;"></div>
+                </div>
               </div>
-              <div class="col-lg-4">
-                <div class="card">
-                  <div class="card-header">
+            </section>
+
+            <!-- Performance por Entregador (largura total) -->
+            <section class="mb-4">
+              <div class="card">
+                <div class="card-header d-flex align-items-center justify-content-between gap-2 flex-wrap">
+                  <div>
                     <h5 class="card-title mb-0">Performance por Entregador</h5>
                     <small class="text-muted">Ranking por volume e custo</small>
                   </div>
-                  <div class="card-body">
-                    <div id="ranking-entregadores-saidas"></div>
+                  <div id="saidas-ranking-view-group" class="btn-group btn-group-sm" role="group" aria-label="Formato do ranking">
+                    <button type="button" class="btn btn-outline-secondary" data-ranking-view="podio" title="Pódio">Pódio</button>
+                    <button type="button" class="btn btn-outline-secondary" data-ranking-view="ranking" title="Lista">Ranking</button>
                   </div>
                 </div>
+                <div class="card-body">
+                  <div id="ranking-entregadores-saidas"></div>
+                </div>
               </div>
-            </div>
+            </section>
 
             <p class="text-center text-muted fs-12 mt-4" id="saidas-dash-footer">Atualizado há poucos segundos</p>
           </div>


### PR DESCRIPTION
## Resumo

Estende o Indicador de Saídas com KPIs de entrada (quando habilitado), layout em largura total e visualização Pódio/Ranking na performance.

## Tipo de alteração

- [x] feature
- [ ] bug
- [ ] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Seção “Entrada na base × saídas” visível só com `entrada_habilitada`
- Cards: total entradas, ainda na base, taxa de saída e gap
- Breakdown de entradas por marketplace
- Evolução Diária e Performance empilhados em largura total
- Toggle Pódio / Ranking (preferência em `localStorage`)
- Séries Entradas e Saídas no gráfico quando entrada está ativa

## Como testar

- Owner **com** entrada: seção de entrada aparece; gráfico mostra Entradas/Saídas
- Owner **sem** entrada: seção oculta; cards de saída e layout novos permanecem
- Alternar Pódio ↔ Ranking e confirmar persistência ao recarregar
- Trocar período e modo Operacional/Entregue e validar refresh

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

Depende do PR em `track_saidas` (mesma branch) com os campos novos do dashboard.

## Checklist

- [ ] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Rollback

Reverter o deploy deste frontend; sem o backend novo a seção de entrada permanece oculta/`entrada` ausente.


Made with [Cursor](https://cursor.com)