### PR TITLE
feat: KPIs de entrada, pódio e link Ainda na base no indicador de saídas

### DIFF
--- a/Master/src/assets/js/pages/dashboard-saidas.init.js
+++ b/Master/src/assets/js/pages/dashboard-saidas.init.js
@@ -97,19 +97,27 @@
     const shopee = items.find(function (x) { return x.nome === "Shopee"; });
     const ml = items.find(function (x) { return x.nome === "Mercado Livre"; });
     const avulso = items.find(function (x) { return x.nome === "Avulso"; });
+    const entradaOn = !!(data && data.entrada_habilitada && data.entrada);
 
     function renderOne(item, prefix) {
       if (!item) return;
       const pct = item.pct ?? 0;
       setText("card-marketplace-" + prefix + "-qty", item.qty ?? 0);
-      setText("card-marketplace-" + prefix + "-pct", pct + "% do total");
+      setText("card-marketplace-" + prefix + "-pct", pct + "% das saídas");
       setText("card-marketplace-" + prefix + "-valor", formatMoeda(item.valor));
       const bar = document.getElementById("bar-marketplace-" + prefix);
       if (bar) bar.style.width = pct + "%";
+      const saidaLabel = document.getElementById("mp-" + prefix + "-saida-label");
+      if (saidaLabel) saidaLabel.textContent = entradaOn ? "Saídas" : "Total";
     }
     renderOne(shopee, "shopee");
     renderOne(ml, "ml");
     renderOne(avulso, "avulso");
+  }
+
+  function fmtDiaCurto(iso) {
+    if (!iso || iso.length < 10) return iso || "";
+    return iso.substr(8, 2) + "/" + iso.substr(5, 2);
   }
 
   function renderEntrada(data) {
@@ -117,6 +125,10 @@
     const subtitle = document.getElementById("saidas-evolucao-subtitle");
     const enabled = !!(data && data.entrada_habilitada && data.entrada);
     if (section) section.classList.toggle("d-none", !enabled);
+    ["shopee", "ml", "avulso"].forEach(function (prefix) {
+      const wrap = document.getElementById("mp-" + prefix + "-entrada-wrap");
+      if (wrap) wrap.classList.toggle("d-none", !enabled);
+    });
     if (subtitle) {
       subtitle.textContent = enabled
         ? "Volume por serviço, entradas e custo acumulado"
@@ -130,21 +142,28 @@
     setText("card-taxa-saida", (e.taxa_saida_pct ?? 0) + "%");
     setText("card-gap-entrada-saida", formatGap(e.gap_entrada_saida));
 
+    const detalheEl = document.getElementById("card-ainda-na-base-detalhe");
+    if (detalheEl) {
+      const detalhe = e.ainda_na_base_detalhe || [];
+      if (!detalhe.length) {
+        detalheEl.textContent = "Nenhum pacote aguardando saída";
+      } else {
+        const top = detalhe.slice(0, 4);
+        detalheEl.innerHTML = top.map(function (d) {
+          return "<div><strong>" + escapeHtml(fmtDiaCurto(d.date)) + "</strong>: " + (d.qty || 0) + " pacote(s)</div>";
+        }).join("") + (detalhe.length > 4
+          ? "<div class='mt-1'>e mais " + (detalhe.length - 4) + " dia(s)</div>"
+          : "");
+      }
+    }
+
     const items = e.por_marketplace || [];
     const shopee = items.find(function (x) { return x.nome === "Shopee"; });
     const ml = items.find(function (x) { return x.nome === "Mercado Livre"; });
     const avulso = items.find(function (x) { return x.nome === "Avulso"; });
-
-    function renderOne(item, prefix) {
-      const pct = item ? (item.pct ?? 0) : 0;
-      setText("card-entrada-" + prefix + "-qty", item ? (item.qty ?? 0) : 0);
-      setText("card-entrada-" + prefix + "-pct", pct + "% do total");
-      const bar = document.getElementById("bar-entrada-" + prefix);
-      if (bar) bar.style.width = pct + "%";
-    }
-    renderOne(shopee, "shopee");
-    renderOne(ml, "ml");
-    renderOne(avulso, "avulso");
+    setText("card-entrada-shopee-qty", shopee ? (shopee.qty ?? 0) : 0);
+    setText("card-entrada-ml-qty", ml ? (ml.qty ?? 0) : 0);
+    setText("card-entrada-avulso-qty", avulso ? (avulso.qty ?? 0) : 0);
   }
 
   function renderCancelamentos(data) {
@@ -305,29 +324,33 @@
     const top = items.slice(0, 3);
     const rest = items.slice(3);
     const leaderVol = (items[0] && items[0].volume) || 1;
-    // Ordem visual: 2º | 1º | 3º
-    const order = [];
-    if (top[1]) order.push({ item: top[1], place: 2 });
-    if (top[0]) order.push({ item: top[0], place: 1 });
-    if (top[2]) order.push({ item: top[2], place: 3 });
+    // Ordem visual: 2º | 1º | 3º — com degraus (pódio)
+    const slots = [
+      { item: top[1], place: 2, stepH: 56, cardPad: "py-3", mt: 36 },
+      { item: top[0], place: 1, stepH: 88, cardPad: "py-4", mt: 0 },
+      { item: top[2], place: 3, stepH: 40, cardPad: "py-3", mt: 52 },
+    ].filter(function (s) { return !!s.item; });
 
-    var html = "<div class='row g-3 align-items-stretch mb-3 justify-content-center'>";
-    order.forEach(function (entry) {
+    var html = "<div class='row g-3 align-items-end mb-2 justify-content-center'>";
+    slots.forEach(function (entry) {
       const r = entry.item;
       const place = entry.place;
       const isFirst = place === 1;
       const medal = PODIUM_MEDALS[place - 1];
       html +=
         "<div class='col-md-4'>" +
-          "<div class='card h-100 border-0 shadow-sm' style='border-top:4px solid " + medal + " !important'>" +
-            "<div class='card-body text-center " + (isFirst ? "py-4" : "py-3") + "'>" +
-              "<div class='rounded-circle d-inline-flex align-items-center justify-content-center mb-2' style='width:" + (isFirst ? 48 : 40) + "px;height:" + (isFirst ? 48 : 40) + "px;background:" + medal + ";color:#fff;font-weight:800'>" + place + "</div>" +
-              "<div class='fw-semibold mb-1' style='font-size:" + (isFirst ? "16px" : "14px") + "'>" + escapeHtml(r.nome) + "</div>" +
-              "<div class='fw-bold text-primary' style='font-size:" + (isFirst ? "28px" : "22px") + "'>" + (r.volume || 0) + "</div>" +
-              "<div class='text-muted mb-2'>" + formatMoeda(r.custo) + "</div>" +
-              "<div class='d-flex flex-wrap justify-content-center gap-1 mb-2'>" + serviceBadges(r) + "</div>" +
-              serviceBar(r) +
+          "<div class='d-flex flex-column' style='margin-top:" + entry.mt + "px'>" +
+            "<div class='card border-0 shadow-sm mb-0' style='border-top:4px solid " + medal + " !important'>" +
+              "<div class='card-body text-center " + entry.cardPad + "'>" +
+                "<div class='rounded-circle d-inline-flex align-items-center justify-content-center mb-2' style='width:" + (isFirst ? 52 : 40) + "px;height:" + (isFirst ? 52 : 40) + "px;background:" + medal + ";color:#fff;font-weight:800;font-size:" + (isFirst ? "18px" : "14px") + "'>" + place + "º</div>" +
+                "<div class='fw-semibold mb-1 px-1' style='font-size:" + (isFirst ? "16px" : "14px") + ";min-height:2.4em'>" + escapeHtml(r.nome) + "</div>" +
+                "<div class='fw-bold text-primary' style='font-size:" + (isFirst ? "32px" : "24px") + ";line-height:1.1'>" + (r.volume || 0) + "</div>" +
+                "<div class='text-muted mb-2'>" + formatMoeda(r.custo) + "</div>" +
+                "<div class='d-flex flex-wrap justify-content-center gap-1 mb-2'>" + serviceBadges(r) + "</div>" +
+                serviceBar(r) +
+              "</div>" +
             "</div>" +
+            "<div class='rounded-bottom text-center text-white fw-bold d-flex align-items-center justify-content-center' style='height:" + entry.stepH + "px;background:" + medal + ";opacity:.92;letter-spacing:.04em'>" + place + "º</div>" +
           "</div>" +
         "</div>";
     });
@@ -335,7 +358,7 @@
 
     if (rest.length) {
       html +=
-        "<div class='mt-2'>" +
+        "<div class='mt-3'>" +
           "<div class='text-muted small mb-2 fw-semibold text-uppercase'>Demais entregadores</div>" +
           renderRankingList(rest, 4, leaderVol) +
         "</div>";

--- a/Master/src/assets/js/pages/dashboard-saidas.init.js
+++ b/Master/src/assets/js/pages/dashboard-saidas.init.js
@@ -143,10 +143,12 @@
     setText("card-gap-entrada-saida", formatGap(e.gap_entrada_saida));
 
     const detalheEl = document.getElementById("card-ainda-na-base-detalhe");
+    const linkEl = document.getElementById("card-ainda-na-base-link");
     if (detalheEl) {
       const detalhe = e.ainda_na_base_detalhe || [];
       if (!detalhe.length) {
         detalheEl.textContent = "Nenhum pacote aguardando saída";
+        if (linkEl) linkEl.href = "tracking-registros.html?status=na_base&periodo=ultimos45";
       } else {
         const top = detalhe.slice(0, 4);
         detalheEl.innerHTML = top.map(function (d) {
@@ -154,6 +156,16 @@
         }).join("") + (detalhe.length > 4
           ? "<div class='mt-1'>e mais " + (detalhe.length - 4) + " dia(s)</div>"
           : "");
+        if (linkEl) {
+          const dates = detalhe.map(function (d) { return d.date; }).filter(Boolean).sort();
+          const de = dates[0];
+          const ate = dates[dates.length - 1];
+          if (de && ate) {
+            linkEl.href = "tracking-registros.html?status=na_base&de=" + encodeURIComponent(de) + "&ate=" + encodeURIComponent(ate);
+          } else {
+            linkEl.href = "tracking-registros.html?status=na_base&periodo=ultimos45";
+          }
+        }
       }
     }
 

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -538,6 +538,7 @@ function augmentEntregadoresFromRows(rows){
     if (!status) return "status-default";
     var s = String(status).toLowerCase().replace(/_/g, " ");
     if (s.indexOf("encerrado") !== -1) return "status-default";
+    if (s.indexOf("na base") !== -1) return "status-warning";
     if (s.indexOf("entregue") !== -1) return "status-success";
     if (s.indexOf("ausente") !== -1) return "status-warning";
     if (s.indexOf("cancelado") !== -1) return "status-danger";
@@ -549,6 +550,7 @@ function augmentEntregadoresFromRows(rows){
     if (status == null || status === "") return "—";
     var s = String(status).replace(/_/g, " ").trim();
     var lower = s.toLowerCase();
+    if (lower === "na base") return "Na Base";
     if (lower === "saiu" || lower === "saiu para entrega") return "SAIU PARA ENTREGA";
     if (lower === "encerrado sistema" || lower === "encerrado pelo sistema" || lower === "encerrado_sistema" || lower === "encerrado") {
       return "Encerrado";
@@ -2532,6 +2534,58 @@ function setupPagerEvents() {
   syncEntregadorDisabled();
   limparFiltrosSelecao();
   if (f.pageSize) f.pageSize.value = String(state.pageSize);
+
+  function applyQueryFiltersFromUrl() {
+    var params;
+    try {
+      params = new URLSearchParams(window.location.search || "");
+    } catch (_) {
+      return false;
+    }
+    var applied = false;
+    var statusRaw = (params.get("status") || "").trim().toLowerCase().replace(/\s+/g, "_");
+    if (statusRaw) {
+      var wanted = statusRaw.replace(/-/g, "_");
+      (f.statusToggles || []).forEach(function (el) {
+        var val = String(el.value || "").toLowerCase().replace(/\s+/g, "_");
+        var match =
+          val === wanted ||
+          (wanted === "na_base" && (val === "na_base" || val === "na base")) ||
+          (wanted === "na base" && val === "na_base");
+        if (match) {
+          el.checked = true;
+          applied = true;
+        }
+      });
+    }
+    var semPeriodo = params.get("sem_periodo") === "1" || params.get("sem_periodo") === "true";
+    if (semPeriodo) {
+      if (f.from) f.from.value = "";
+      if (f.to) f.to.value = "";
+      var periodLabel = document.getElementById("registros-period-label");
+      if (periodLabel) periodLabel.textContent = "Todos os períodos";
+      applied = true;
+    }
+    var de = (params.get("de") || params.get("data_inicio") || "").trim();
+    var ate = (params.get("ate") || params.get("data_fim") || "").trim();
+    if (!semPeriodo && (de || ate)) {
+      if (f.from && de) f.from.value = de;
+      if (f.to && ate) f.to.value = ate;
+      else if (f.to && de && !ate) f.to.value = de;
+      updatePeriodLabel(f.from ? f.from.value : "", f.to ? f.to.value : "");
+      applied = true;
+    }
+    // Limpa query da URL sem recarregar (evita reaplicar ao refresh manual)
+    if (applied && window.history && window.history.replaceState) {
+      try {
+        var clean = window.location.pathname + (window.location.hash || "");
+        window.history.replaceState({}, document.title, clean);
+      } catch (_) {}
+    }
+    return applied;
+  }
+
+  applyQueryFiltersFromUrl();
   refresh(false);
   updateEditButtonState();
   if (typeof atualizarContadorFiltros === "function") atualizarContadorFiltros();

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -2558,23 +2558,36 @@ function setupPagerEvents() {
         }
       });
     }
-    var semPeriodo = params.get("sem_periodo") === "1" || params.get("sem_periodo") === "true";
-    if (semPeriodo) {
-      if (f.from) f.from.value = "";
-      if (f.to) f.to.value = "";
-      var periodLabel = document.getElementById("registros-period-label");
-      if (periodLabel) periodLabel.textContent = "Todos os períodos";
-      applied = true;
-    }
+
     var de = (params.get("de") || params.get("data_inicio") || "").trim();
     var ate = (params.get("ate") || params.get("data_fim") || "").trim();
-    if (!semPeriodo && (de || ate)) {
+    var periodo = (params.get("periodo") || "").trim().toLowerCase();
+    var semPeriodo = params.get("sem_periodo") === "1" || params.get("sem_periodo") === "true";
+
+    // "Todos os períodos" na listagem pesada costuma falhar/zerar; para Na Base usamos período amplo.
+    if (semPeriodo && !de && !ate && !periodo) {
+      periodo = "ultimos45";
+      semPeriodo = false;
+    }
+
+    if (de || ate) {
       if (f.from && de) f.from.value = de;
       if (f.to && ate) f.to.value = ate;
       else if (f.to && de && !ate) f.to.value = de;
       updatePeriodLabel(f.from ? f.from.value : "", f.to ? f.to.value : "");
       applied = true;
+    } else if (periodo && datePickerInstance && datePickerInstance.applyPreset) {
+      var allowed = { ultimos15: 1, ultimos30: 1, ultimos45: 1, hoje: 1, ontem: 1, quinzena: 1, mes: 1 };
+      if (allowed[periodo]) {
+        datePickerInstance.applyPreset(periodo);
+        var r = datePickerInstance.getResolvedRange();
+        if (f.from) f.from.value = r.start || "";
+        if (f.to) f.to.value = r.end || "";
+        updatePeriodLabel(r.start || "", r.end || "");
+        applied = true;
+      }
     }
+
     // Limpa query da URL sem recarregar (evita reaplicar ao refresh manual)
     if (applied && window.history && window.history.replaceState) {
       try {

--- a/Master/src/dashboard-saidas.html
+++ b/Master/src/dashboard-saidas.html
@@ -141,8 +141,13 @@
                       <div class="d-flex align-items-start justify-content-between">
                         <div class="flex-grow-1 min-w-0">
                           <p class="text-muted mb-1">Ainda na base</p>
-                          <h4 class="mb-1"><span id="card-ainda-na-base">0</span></h4>
-                          <small class="text-muted d-block mb-1">Estoque atual aguardando saída</small>
+                          <h4 class="mb-1">
+                            <a id="card-ainda-na-base-link" href="tracking-registros.html?status=na_base&amp;sem_periodo=1" class="text-decoration-none text-reset" title="Ver pacotes na base em Registros">
+                              <span id="card-ainda-na-base">0</span>
+                              <i class="ri-external-link-line fs-6 text-muted ms-1" aria-hidden="true"></i>
+                            </a>
+                          </h4>
+                          <small class="text-muted d-block mb-1">Estoque atual aguardando saída — clique para ver em Registros</small>
                           <div id="card-ainda-na-base-detalhe" class="small text-muted" style="line-height:1.35"></div>
                         </div>
                         <i class="bx bx-home-alt fs-2 text-dark"></i>

--- a/Master/src/dashboard-saidas.html
+++ b/Master/src/dashboard-saidas.html
@@ -119,17 +119,17 @@
               <div class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2">
                 <div>
                   <h5 class="mb-0 fs-16">Entrada na base × saídas</h5>
-                  <small class="text-muted">Quanto entrou, o que ainda está na base e a proporção com as saídas</small>
+                  <small class="text-muted">Estoque atual na base e movimento do período filtrado</small>
                 </div>
               </div>
-              <div class="row g-3 mb-3">
+              <div class="row g-3">
                 <div class="col-6 col-xl-3">
                   <div class="card card-height-100 border border-secondary">
                     <div class="card-body d-flex align-items-center">
                       <div class="flex-grow-1">
                         <p class="text-muted mb-1">Total de Entradas</p>
                         <h4 class="mb-0"><span id="card-total-entradas">0</span></h4>
-                        <small class="text-muted">Pacotes no período</small>
+                        <small class="text-muted">Entraram no período</small>
                       </div>
                       <i class="bx bx-log-in-circle fs-2 text-secondary"></i>
                     </div>
@@ -137,13 +137,16 @@
                 </div>
                 <div class="col-6 col-xl-3">
                   <div class="card card-height-100 border border-dark">
-                    <div class="card-body d-flex align-items-center">
-                      <div class="flex-grow-1">
-                        <p class="text-muted mb-1">Ainda na base</p>
-                        <h4 class="mb-0"><span id="card-ainda-na-base">0</span></h4>
-                        <small class="text-muted">Aguardando saída</small>
+                    <div class="card-body">
+                      <div class="d-flex align-items-start justify-content-between">
+                        <div class="flex-grow-1 min-w-0">
+                          <p class="text-muted mb-1">Ainda na base</p>
+                          <h4 class="mb-1"><span id="card-ainda-na-base">0</span></h4>
+                          <small class="text-muted d-block mb-1">Estoque atual aguardando saída</small>
+                          <div id="card-ainda-na-base-detalhe" class="small text-muted" style="line-height:1.35"></div>
+                        </div>
+                        <i class="bx bx-home-alt fs-2 text-dark"></i>
                       </div>
-                      <i class="bx bx-home-alt fs-2 text-dark"></i>
                     </div>
                   </div>
                 </div>
@@ -153,7 +156,7 @@
                       <div class="flex-grow-1">
                         <p class="text-muted mb-1">Taxa de saída</p>
                         <h4 class="mb-0"><span id="card-taxa-saida">0%</span></h4>
-                        <small class="text-muted">Saídas ÷ entradas</small>
+                        <small class="text-muted">Saídas ÷ entradas no período</small>
                       </div>
                       <i class="bx bx-pie-chart-alt-2 fs-2 text-primary"></i>
                     </div>
@@ -163,73 +166,38 @@
                   <div class="card card-height-100 border border-warning">
                     <div class="card-body d-flex align-items-center">
                       <div class="flex-grow-1">
-                        <p class="text-muted mb-1">Gap (entrou − saiu)</p>
+                        <p class="text-muted mb-1">Saldo do período</p>
                         <h4 class="mb-0"><span id="card-gap-entrada-saida">0</span></h4>
-                        <small class="text-muted">Diferença no período</small>
+                        <small class="text-muted">Entradas − saídas do filtro (não é o estoque)</small>
                       </div>
                       <i class="bx bx-git-compare fs-2 text-warning"></i>
                     </div>
                   </div>
                 </div>
               </div>
-              <div class="row g-3">
-                <div class="col-md-4">
-                  <div class="card border overflow-hidden" style="border-color: rgba(238,77,45,0.5) !important; border-left: 4px solid #ee4d2d !important;">
-                    <div class="card-body">
-                      <h6 class="card-title text-uppercase mb-2">Entradas · Shopee</h6>
-                      <div class="d-flex justify-content-between align-items-baseline mb-1">
-                        <span class="fs-4 fw-bold" id="card-entrada-shopee-qty">0</span>
-                        <span class="text-muted small" id="card-entrada-shopee-pct">0% do total</span>
-                      </div>
-                      <div class="progress" style="height: 6px;">
-                        <div class="progress-bar" style="background-color: #ee4d2d; width: 0%;" id="bar-entrada-shopee"></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="col-md-4">
-                  <div class="card border overflow-hidden" style="border-color: rgba(255,230,0,0.6) !important; border-left: 4px solid #ffe600 !important;">
-                    <div class="card-body">
-                      <h6 class="card-title text-uppercase mb-2">Entradas · Mercado Livre</h6>
-                      <div class="d-flex justify-content-between align-items-baseline mb-1">
-                        <span class="fs-4 fw-bold" id="card-entrada-ml-qty">0</span>
-                        <span class="text-muted small" id="card-entrada-ml-pct">0% do total</span>
-                      </div>
-                      <div class="progress" style="height: 6px;">
-                        <div class="progress-bar" style="background-color: #ffe600; width: 0%;" id="bar-entrada-ml"></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="col-md-4">
-                  <div class="card border overflow-hidden" style="border-color: rgba(108,117,125,0.5) !important; border-left: 4px solid #6c757d !important;">
-                    <div class="card-body">
-                      <h6 class="card-title text-uppercase mb-2">Entradas · Avulso</h6>
-                      <div class="d-flex justify-content-between align-items-baseline mb-1">
-                        <span class="fs-4 fw-bold" id="card-entrada-avulso-qty">0</span>
-                        <span class="text-muted small" id="card-entrada-avulso-pct">0% do total</span>
-                      </div>
-                      <div class="progress" style="height: 6px;">
-                        <div class="progress-bar" style="background-color: #6c757d; width: 0%;" id="bar-entrada-avulso"></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
             </section>
 
-            <!-- Cards por marketplace (saídas) -->
+            <!-- Cards por marketplace (saídas; com entrada unificada quando habilitada) -->
             <section class="mb-4">
               <div class="row g-3">
                 <div class="col-md-4">
                   <div class="card border overflow-hidden" style="border-color: rgba(238,77,45,0.5) !important; border-left: 4px solid #ee4d2d !important;">
                     <div class="card-body">
                       <h6 class="card-title text-uppercase mb-2">Shopee</h6>
+                      <div id="mp-shopee-entrada-wrap" class="d-none mb-2">
+                        <div class="d-flex justify-content-between align-items-baseline">
+                          <span class="text-muted small">Entradas</span>
+                          <span class="fw-semibold" id="card-entrada-shopee-qty">0</span>
+                        </div>
+                      </div>
                       <div class="d-flex justify-content-between align-items-baseline mb-1">
+                        <span class="text-muted small" id="mp-shopee-saida-label">Saídas</span>
                         <span class="fs-4 fw-bold" id="card-marketplace-shopee-qty">0</span>
+                      </div>
+                      <div class="d-flex justify-content-between align-items-baseline mb-2">
+                        <span class="text-success small" id="card-marketplace-shopee-valor">R$ 0,00</span>
                         <span class="text-muted small" id="card-marketplace-shopee-pct">0% do total</span>
                       </div>
-                      <div class="text-success small mb-2" id="card-marketplace-shopee-valor">R$ 0,00</div>
                       <div class="progress" style="height: 6px;">
                         <div class="progress-bar bg-opacity-75" style="background-color: #ee4d2d; width: 0%;" id="bar-marketplace-shopee"></div>
                       </div>
@@ -240,11 +208,20 @@
                   <div class="card border overflow-hidden" style="border-color: rgba(255,230,0,0.6) !important; border-left: 4px solid #ffe600 !important;">
                     <div class="card-body">
                       <h6 class="card-title text-uppercase mb-2">Mercado Livre</h6>
+                      <div id="mp-ml-entrada-wrap" class="d-none mb-2">
+                        <div class="d-flex justify-content-between align-items-baseline">
+                          <span class="text-muted small">Entradas</span>
+                          <span class="fw-semibold" id="card-entrada-ml-qty">0</span>
+                        </div>
+                      </div>
                       <div class="d-flex justify-content-between align-items-baseline mb-1">
+                        <span class="text-muted small" id="mp-ml-saida-label">Saídas</span>
                         <span class="fs-4 fw-bold" id="card-marketplace-ml-qty">0</span>
+                      </div>
+                      <div class="d-flex justify-content-between align-items-baseline mb-2">
+                        <span class="text-success small" id="card-marketplace-ml-valor">R$ 0,00</span>
                         <span class="text-muted small" id="card-marketplace-ml-pct">0% do total</span>
                       </div>
-                      <div class="text-success small mb-2" id="card-marketplace-ml-valor">R$ 0,00</div>
                       <div class="progress" style="height: 6px;">
                         <div class="progress-bar bg-opacity-75" style="background-color: #ffe600; width: 0%;" id="bar-marketplace-ml"></div>
                       </div>
@@ -255,11 +232,20 @@
                   <div class="card border overflow-hidden" style="border-color: rgba(108,117,125,0.5) !important; border-left: 4px solid #6c757d !important;">
                     <div class="card-body">
                       <h6 class="card-title text-uppercase mb-2">Avulso</h6>
+                      <div id="mp-avulso-entrada-wrap" class="d-none mb-2">
+                        <div class="d-flex justify-content-between align-items-baseline">
+                          <span class="text-muted small">Entradas</span>
+                          <span class="fw-semibold" id="card-entrada-avulso-qty">0</span>
+                        </div>
+                      </div>
                       <div class="d-flex justify-content-between align-items-baseline mb-1">
+                        <span class="text-muted small" id="mp-avulso-saida-label">Saídas</span>
                         <span class="fs-4 fw-bold" id="card-marketplace-avulso-qty">0</span>
+                      </div>
+                      <div class="d-flex justify-content-between align-items-baseline mb-2">
+                        <span class="text-success small" id="card-marketplace-avulso-valor">R$ 0,00</span>
                         <span class="text-muted small" id="card-marketplace-avulso-pct">0% do total</span>
                       </div>
-                      <div class="text-success small mb-2" id="card-marketplace-avulso-valor">R$ 0,00</div>
                       <div class="progress" style="height: 6px;">
                         <div class="progress-bar bg-opacity-75" style="background-color: #6c757d; width: 0%;" id="bar-marketplace-avulso"></div>
                       </div>

--- a/Master/src/dashboard-saidas.html
+++ b/Master/src/dashboard-saidas.html
@@ -142,7 +142,7 @@
                         <div class="flex-grow-1 min-w-0">
                           <p class="text-muted mb-1">Ainda na base</p>
                           <h4 class="mb-1">
-                            <a id="card-ainda-na-base-link" href="tracking-registros.html?status=na_base&amp;sem_periodo=1" class="text-decoration-none text-reset" title="Ver pacotes na base em Registros">
+                            <a id="card-ainda-na-base-link" href="tracking-registros.html?status=na_base&amp;periodo=ultimos45" class="text-decoration-none text-reset" title="Ver pacotes na base em Registros">
                               <span id="card-ainda-na-base">0</span>
                               <i class="ri-external-link-line fs-6 text-muted ms-1" aria-hidden="true"></i>
                             </a>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -106,6 +106,10 @@
                             <div class="accordion-body pt-2 pb-1">
                               <div id="flt-status-toggle" class="filtro-switch-list d-flex flex-column gap-1">
                                 <div class="form-check form-switch">
+                                  <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-nabase" value="na_base">
+                                  <label class="form-check-label small" for="flt-status-nabase">Na base</label>
+                                </div>
+                                <div class="form-check form-switch">
                                   <input class="form-check-input filtro-toggle-item" type="checkbox" id="flt-status-saiu" value="saiu">
                                   <label class="form-check-label small" for="flt-status-saiu">Saiu para entrega</label>
                                 </div>


### PR DESCRIPTION
## Resumo

Estende o Indicador de Saídas com KPIs de entrada, layout full width, pódio/ranking e deep-link do estoque “Ainda na base” para Registros.

## Tipo de alteração

- [x] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Seção entrada × saídas (condicional à flag do owner)
- Cards unificados por serviço (entradas + saídas)
- Layout full width; toggle Pódio / Ranking
- Status **Na base** no filtro de Registros
- Link do KPI “Ainda na base” com período (`de`/`ate` do estoque ou últimos 45 dias)

## Como testar

- Owner **com** entrada: seção e séries Entradas/Saídas no gráfico
- Owner **sem** entrada: seção oculta; layout/pódio permanecem
- Clicar em “Ainda na base” → Registros com status Na base + período e lista preenchida
- Alternar Pódio ↔ Ranking

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

Depende do PR em `track_saidas` (mesma branch). Deploy: backend primeiro.

## Checklist

- [ ] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Rollback

Reverter o deploy deste frontend.


Made with [Cursor](https://cursor.com)