### PR TITLE
fix: estabiliza responsividade web em monitores e zoom

### DIFF
--- a/Master/src/admin-owners.html
+++ b/Master/src/admin-owners.html
@@ -107,11 +107,11 @@
 @@include("partials/vendor-scripts.html")
 
 <!-- ===================== OFFCANVAS: FORMULÁRIO EDITAR ===================== -->
-<div class="offcanvas offcanvas-end offcanvas-form"
+<div class="offcanvas offcanvas-end offcanvas-form offcanvas-form--w520"
      tabindex="-1"
      id="oc-owner"
      aria-labelledby="ocLabel"
-     style="width:520px"
+     
      data-bs-scroll="false"
      data-bs-backdrop="true">
 

--- a/Master/src/assets/js/layout.js
+++ b/Master/src/assets/js/layout.js
@@ -10,6 +10,14 @@
     "data-sidebar-image","data-theme-colors","data-preloader"
   ].forEach(k => localStorage.removeItem(k));
 
+  /** Sidebar compacta em viewport estreita / zoom alto (área útil). */
+  function sidebarSizeForViewport() {
+    const w = window.innerWidth || document.documentElement.clientWidth || 1200;
+    if (w < 992) return "sm";
+    if (w < 1200) return "md";
+    return "lg";
+  }
+
   // 2) Aplica os atributos padrão do layout
   function applyDefaults() {
     R.setAttribute("data-bs-theme", "light");      // Color Scheme
@@ -19,7 +27,7 @@
     R.setAttribute("data-topbar", "dark");         // Topbar Color
     R.setAttribute("data-sidebar", "gradient");    // Sidebar Color (gradient)
     R.setAttribute("data-sidebar-color", "gradient-1"); // 1ª bolinha do gradient (se suportado)
-    R.setAttribute("data-sidebar-size", "lg");     // Sidebar Size (Default)
+    R.setAttribute("data-sidebar-size", sidebarSizeForViewport());
     R.setAttribute("data-theme", "default");       // Theme (Default)
     R.setAttribute("data-preloader", "disable");    // Preloader ligado (se suportado)
   }
@@ -28,6 +36,14 @@
   document.addEventListener("DOMContentLoaded", () => {
     applyDefaults();
     setTimeout(applyDefaults, 0);
+  });
+
+  let resizeTimer = null;
+  window.addEventListener("resize", () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      R.setAttribute("data-sidebar-size", sidebarSizeForViewport());
+    }, 150);
   });
 
   // 4) Desativa qualquer input do customizer caso o HTML ainda exista

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -746,9 +746,9 @@ function augmentEntregadoresFromRows(rows){
             <td>${renderActionBadge(r.acao)}</td>
             <td>${formatPersonNameOrDash(r.entregador)}</td>
             <td>${r.tsAcaoFmt || ""}</td>
-            <td>${r.tsEntradaFmt || ""}</td>
-            <td>${r.executado_por || "—"}</td>
-            <td class="text-muted">${r.seller || "-"}</td>
+            <td class="d-none d-xl-table-cell">${r.tsEntradaFmt || ""}</td>
+            <td class="d-none d-xl-table-cell">${r.executado_por || "—"}</td>
+            <td class="d-none d-xl-table-cell text-muted">${r.seller || "-"}</td>
             <td class="text-center">${gCell}</td>
           </tr>`;
       })

--- a/Master/src/assets/scss/custom.scss
+++ b/Master/src/assets/scss/custom.scss
@@ -42,8 +42,9 @@
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 280px;
-    height: 280px;
+    width: min(280px, 70vw);
+    height: min(280px, 70vw);
+    max-height: min(280px, 50vh);
     transform: translate(-50%, -50%);
     border-radius: 20px;
 
@@ -250,13 +251,21 @@
 /* OFFCANVAS COM FORM EM COLUNA (cadastros/configurações) */
 #oc-form.offcanvas,
 .offcanvas-form {
+  --oc-w: 480px;
   position: fixed;
   inset: 0 auto 0 auto;
   display: flex;
   flex-direction: column;
   height: 100vh;
   max-height: 100vh;
+  width: min(var(--oc-w), 100vw) !important;
+  max-width: 100vw !important;
 }
+.offcanvas-form--w400 { --oc-w: 400px; }
+.offcanvas-form--w460 { --oc-w: 460px; }
+.offcanvas-form--w480 { --oc-w: 480px; }
+.offcanvas-form--w520 { --oc-w: 520px; }
+.offcanvas-form--w900 { --oc-w: 900px; }
 #oc-form .offcanvas-header,
 .offcanvas-form .offcanvas-header {
   flex: 0 0 auto;
@@ -665,7 +674,10 @@
   #coletas-period-panel,
   #fin-period-panel,
   #contabilidade-period-panel,
-  #entregadores-resumo-period-panel {
+  #entregadores-resumo-period-panel,
+  #a-pagar-period-panel,
+  .period-panel,
+  .period-panel-sm {
     min-width: 0 !important;
     width: 100vw !important;
     max-width: calc(100vw - 1rem) !important;
@@ -867,6 +879,167 @@
   .acom-ranking-rank {
     font-weight: 700;
     color: #6c757d;
+  }
+}
+
+/* ===================================================
+   RESPONSIVIDADE DESKTOP ESTREITO / ZOOM (1280–1920 @ 100–150%)
+   Painéis, offcanvas e KPIs fluidos — não só mobile ≤768.
+   =================================================== */
+
+:root {
+  --ts-sidebar-w: var(--vz-vertical-menu-width, 250px);
+  --ts-period-gutter: 2rem;
+}
+
+/* Painéis de período (dropdown date picker) */
+.period-panel,
+#registros-period-panel,
+#saidas-period-panel,
+#coletas-period-panel,
+#coletas-resumo-period-panel,
+#admin-period-panel,
+#visao360-period-panel,
+#fin-period-panel,
+#contabilidade-period-panel,
+#entregadores-resumo-period-panel,
+#a-pagar-period-panel {
+  min-width: 0 !important;
+  width: min(640px, calc(100vw - var(--ts-period-gutter) - var(--ts-sidebar-w))) !important;
+  max-width: calc(100vw - 1rem) !important;
+}
+
+.period-panel-sm,
+#admin-period-panel,
+#visao360-period-panel,
+#coletas-period-panel,
+#fin-period-panel,
+#saidas-period-panel {
+  width: min(540px, calc(100vw - var(--ts-period-gutter) - var(--ts-sidebar-w))) !important;
+}
+
+.filter-menu {
+  min-width: 0 !important;
+  width: min(280px, calc(100vw - 1rem)) !important;
+  max-width: calc(100vw - 1rem) !important;
+}
+
+.table-card {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
+}
+
+.modal-dialog {
+  max-width: min(var(--bs-modal-width, 500px), calc(100vw - 1rem));
+}
+.modal-dialog.modal-lg {
+  max-width: min(800px, calc(100vw - 1rem));
+}
+.modal-dialog.modal-xl {
+  max-width: min(1140px, calc(100vw - 1rem));
+}
+
+/* Date picker em coluna quando a área útil aperta (zoom / notebook) */
+@media (max-width: 1199.98px) {
+  .date-picker-dashboard .row {
+    flex-direction: column;
+  }
+  .date-picker-dashboard .row .col-4,
+  .date-picker-dashboard .row .col-8 {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .kpi-row,
+  .row.flex-nowrap {
+    flex-wrap: wrap !important;
+  }
+
+  .row.flex-nowrap > [class*="col"] {
+    flex: 1 1 140px;
+    min-width: 140px;
+    max-width: 100%;
+  }
+
+  /* Usuários (offcanvas 900): formulário em 1 coluna */
+  .offcanvas-form--w900 #colUser,
+  .offcanvas-form--w900 #colMotoboy {
+    flex: 0 0 100% !important;
+    max-width: 100% !important;
+  }
+  .offcanvas-form--w900 .offcanvas-body .col-6 {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+
+  /* Painel detalhe de registros: mais altura em viewport estreita */
+  .reg-detail-panel {
+    max-height: 85vh;
+  }
+}
+
+/* Cards densos (dashboards): evita overflow horizontal com zoom */
+.page-content .row > [class*="col"] {
+  min-width: 0;
+}
+
+/* Charts dashboards — altura fluida com zoom / viewport baixa */
+.chart-responsive {
+  width: 100% !important;
+  height: min(280px, 40vh) !important;
+  min-height: 180px;
+}
+.chart-responsive--sm {
+  height: min(220px, 35vh) !important;
+  min-height: 160px;
+}
+
+/* Etiquetas preview */
+.etiquetas-preview-frame {
+  width: 100% !important;
+  height: min(600px, 70vh) !important;
+  max-width: 100%;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+}
+
+/* Scanner: moldura e HUD em viewport baixa / estreita */
+.scanfs-frame {
+  width: min(280px, 70vw) !important;
+  height: min(280px, 70vw) !important;
+  max-height: min(280px, 50vh);
+}
+
+@media (max-height: 700px) {
+  .scanfs .scanfs-hud,
+  .scanfs [class*="hud"],
+  .scanfs .scanfs-bottom {
+    max-height: 42vh;
+    overflow-y: auto;
+  }
+}
+
+/* Toolbars densas: permitem wrap em desktop estreito */
+.registros-toolbar,
+.ent-toolbar,
+.page-title-box .d-flex {
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+/* Offcanvas acompanhamento sem width inline */
+#ocMotoboyDetail.offcanvas {
+  --oc-w: 480px;
+  width: min(var(--oc-w), 100vw) !important;
+  max-width: 100vw !important;
+}
+
+@media (max-width: 991.98px) {
+  .profile-settings-fluid .row > [class*="col-"] {
+    flex: 0 0 100%;
+    max-width: 100%;
   }
 }
 

--- a/Master/src/dashboard-admin.html
+++ b/Master/src/dashboard-admin.html
@@ -53,7 +53,7 @@
                     <i class="bx bx-calendar"></i>
                     <span id="admin-period-label">Hoje</span>
                   </button>
-                  <div class="dropdown-menu dropdown-menu-end p-0" id="admin-period-panel" style="min-width: 540px;">
+                  <div class="dropdown-menu dropdown-menu-end p-0 period-panel-sm" id="admin-period-panel">
                     <input type="hidden" id="admin-data-inicio" />
                     <input type="hidden" id="admin-data-fim" />
                     <div id="admin-date-picker-container"></div>
@@ -125,7 +125,7 @@
                   <small class="text-muted">Comparativo de coletas, saídas e receita</small>
                 </div>
                 <div class="card-body">
-                  <div id="chart-volume-owner" style="height: 280px;"></div>
+                  <div id="chart-volume-owner" class="chart-responsive"></div>
                 </div>
               </div>
             </section>

--- a/Master/src/dashboard-coletas.html
+++ b/Master/src/dashboard-coletas.html
@@ -53,7 +53,7 @@
                     <i class="bx bx-calendar"></i>
                     <span id="coletas-period-label">Hoje</span>
                   </button>
-                  <div class="dropdown-menu dropdown-menu-end p-0" id="coletas-period-panel" style="min-width: 540px;">
+                  <div class="dropdown-menu dropdown-menu-end p-0 period-panel-sm" id="coletas-period-panel">
                     <input type="hidden" id="coletas-data-inicio" />
                     <input type="hidden" id="coletas-data-fim" />
                     <div id="coletas-date-picker-container"></div>
@@ -190,7 +190,7 @@
                   <i class="bx bx-info-circle text-muted fs-16" style="cursor:help" data-bs-toggle="tooltip" data-bs-placement="top" title="Quantidade de bases que tiveram e não tiveram coletas em cada dia do período."></i>
                 </div>
                 <div class="card-body">
-                  <div id="chart-bases-por-dia" style="height: 220px;"></div>
+                  <div id="chart-bases-por-dia" class="chart-responsive chart-responsive--sm"></div>
                 </div>
               </div>
             </section>
@@ -262,7 +262,7 @@
                     </div>
                   </div>
                   <div class="card-body">
-                    <div id="chart-coletas-periodo" style="height: 280px;"></div>
+                    <div id="chart-coletas-periodo" class="chart-responsive"></div>
                   </div>
                 </div>
               </div>

--- a/Master/src/dashboard-financeiro.html
+++ b/Master/src/dashboard-financeiro.html
@@ -50,7 +50,7 @@
                     <i class="bx bx-calendar"></i>
                     <span id="fin-period-label">Hoje</span>
                   </button>
-                  <div class="dropdown-menu dropdown-menu-end p-0" id="fin-period-panel" style="min-width: 540px;">
+                  <div class="dropdown-menu dropdown-menu-end p-0 period-panel-sm" id="fin-period-panel">
                     <input type="hidden" id="fin-data-inicio" />
                     <input type="hidden" id="fin-data-fim" />
                     <div id="fin-date-picker-container"></div>
@@ -134,7 +134,7 @@
                   </div>
                 </div>
                 <div class="card-body">
-                  <div id="chart-evolucao-financeira" style="height: 280px;"></div>
+                  <div id="chart-evolucao-financeira" class="chart-responsive"></div>
                 </div>
               </div>
             </section>

--- a/Master/src/dashboard-saidas.html
+++ b/Master/src/dashboard-saidas.html
@@ -50,7 +50,7 @@
                     <i class="bx bx-calendar"></i>
                     <span id="saidas-period-label">Hoje</span>
                   </button>
-                  <div class="dropdown-menu dropdown-menu-end p-0" id="saidas-period-panel" style="min-width: 540px;">
+                  <div class="dropdown-menu dropdown-menu-end p-0 period-panel-sm" id="saidas-period-panel">
                     <input type="hidden" id="saidas-data-inicio" />
                     <input type="hidden" id="saidas-data-fim" />
                     <div id="saidas-date-picker-container"></div>
@@ -195,7 +195,7 @@
                     </div>
                   </div>
                   <div class="card-body">
-                    <div id="chart-evolucao-saidas" style="height: 280px;"></div>
+                    <div id="chart-evolucao-saidas" class="chart-responsive"></div>
                   </div>
                 </div>
               </div>

--- a/Master/src/dashboard-visao-360.html
+++ b/Master/src/dashboard-visao-360.html
@@ -42,7 +42,7 @@
                     <i class="bx bx-calendar"></i>
                     <span id="visao360-period-label">Hoje</span>
                   </button>
-                  <div class="dropdown-menu dropdown-menu-end p-0" id="visao360-period-panel" style="min-width: 540px;">
+                  <div class="dropdown-menu dropdown-menu-end p-0 period-panel-sm" id="visao360-period-panel">
                     <input type="hidden" id="visao360-data-inicio" />
                     <input type="hidden" id="visao360-data-fim" />
                     <div id="visao360-date-picker-container"></div>
@@ -289,7 +289,7 @@
                   <small class="text-muted">Coletas vs Saídas + Taxa de Conversão</small>
                 </div>
                 <div class="card-body py-2">
-                  <div id="chart-evolucao-diaria" style="height: 260px;"></div>
+                  <div id="chart-evolucao-diaria" class="chart-responsive"></div>
                 </div>
               </div>
 

--- a/Master/src/profile-settings-tracking.html
+++ b/Master/src/profile-settings-tracking.html
@@ -13,7 +13,7 @@
       @@include("partials/menu.html")
 
       <div class="main-content">
-        <div class="page-content">
+        <div class="page-content profile-settings-fluid">
           <div class="container-fluid">
 
             <!-- Título padrão -->

--- a/Master/src/tracking-acompanhamento.html
+++ b/Master/src/tracking-acompanhamento.html
@@ -39,7 +39,7 @@
                             <i class="ri-filter-3-line me-1"></i> Filtros
                             <span id="filtrosContador" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary d-none">0</span>
                           </button>
-                          <div class="dropdown-menu dropdown-menu-end p-3" style="min-width: 280px;">
+                          <div class="dropdown-menu dropdown-menu-end p-3 filter-menu">
                             <div class="mb-3">
                               <label class="form-label small" id="flt-motoboy-label">Motoboy</label>
                               <select id="flt-motoboy" class="form-select form-select-sm">
@@ -132,7 +132,7 @@
                     </div>
 
                     <!-- KPIs totalizadores -->
-                    <div class="row g-2 mb-3 flex-nowrap">
+                    <div class="row g-2 mb-3 flex-nowrap kpi-row">
                       <div class="col flex-fill" style="min-width: 0;">
                         <div class="p-3 rounded text-center bg-light border">
                           <span class="small text-secondary fw-semibold d-block">Total pedidos</span>
@@ -240,7 +240,7 @@
     </div>
 
     <!-- Detalhe do motoboy -->
-    <div class="offcanvas offcanvas-end offcanvas-form" tabindex="-1" id="ocMotoboyDetail" aria-labelledby="ocMotoboyDetailLabel">
+    <div class="offcanvas offcanvas-end offcanvas-form offcanvas-form--w480" tabindex="-1" id="ocMotoboyDetail" aria-labelledby="ocMotoboyDetailLabel">
       <div class="offcanvas-header border-bottom">
         <h5 class="offcanvas-title" id="ocMotoboyDetailLabel">Detalhe do motoboy</h5>
         <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Fechar"></button>

--- a/Master/src/tracking-autenticacao.html
+++ b/Master/src/tracking-autenticacao.html
@@ -60,7 +60,7 @@
                         </button>
                     </div>
                     <div class="card-body">
-                        <div class="table-responsive">
+                        <div class="table-responsive table-card">
                             <table class="table table-striped align-middle table-nowrap" id="tbl-sellers">
                                 <thead class="table-light">
                                     <tr>

--- a/Master/src/tracking-avisos.html
+++ b/Master/src/tracking-avisos.html
@@ -58,12 +58,12 @@
               </div>
               <div class="col-lg-7">
                 <div class="card">
-                  <div class="card-header d-flex justify-content-between align-items-center">
+                  <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
                     <h5 class="card-title mb-0">Histórico recente</h5>
                     <button type="button" id="btn-atualizar-avisos" class="btn btn-sm btn-soft-primary">Atualizar</button>
                   </div>
                   <div class="card-body">
-                    <div class="table-responsive">
+                    <div class="table-responsive table-card">
                       <table class="table table-sm align-middle mb-0">
                         <thead>
                           <tr>

--- a/Master/src/tracking-base.html
+++ b/Master/src/tracking-base.html
@@ -132,11 +132,11 @@
     @@include("partials/vendor-scripts.html")
 
     <!-- Offcanvas: Formulário -->
-    <div class="offcanvas offcanvas-end offcanvas-form"
+    <div class="offcanvas offcanvas-end offcanvas-form offcanvas-form--w480"
          tabindex="-1"
          id="oc-form"
          aria-labelledby="ocLabel"
-         style="width:480px; display:flex; flex-direction:column;"
+         style="display:flex; flex-direction:column;"
          data-bs-scroll="false"
          data-bs-backdrop="true">
       <div class="offcanvas-header border-bottom">
@@ -245,7 +245,7 @@
 
     <!-- Modal de exclusão -->
     <div class="modal fade" id="modalDelete" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-body text-center p-4">
             <lord-icon src="https://cdn.lordicon.com/gsqxdxog.json" trigger="loop"

--- a/Master/src/tracking-campos-obrigatorios-servico.html
+++ b/Master/src/tracking-campos-obrigatorios-servico.html
@@ -61,7 +61,7 @@
     @@include("partials/customizer.html")
     @@include("partials/vendor-scripts.html")
 
-    <div class="offcanvas offcanvas-end offcanvas-form" tabindex="-1" id="oc-rule" aria-labelledby="ocRuleLabel" style="width: 460px">
+    <div class="offcanvas offcanvas-end offcanvas-form offcanvas-form--w460" tabindex="-1" id="oc-rule" aria-labelledby="ocRuleLabel" >
       <div class="offcanvas-header border-bottom">
         <h5 class="offcanvas-title" id="ocRuleLabel">Nova regra</h5>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>

--- a/Master/src/tracking-coleta-leitura.html
+++ b/Master/src/tracking-coleta-leitura.html
@@ -144,7 +144,7 @@
                   <p class="text-muted text-uppercase modo-monitor-section-label mb-2">Total de leituras</p>
                   <p id="monitor-total" class="modo-monitor-total-num text-primary mb-0">0</p>
                 </div>
-                <div class="row g-3 g-md-4 w-100 justify-content-center" style="max-width: 1000px;">
+                <div class="row g-3 g-md-4 w-100 justify-content-center" style="max-width: min(1000px, 100%);">
                   <div class="col-4">
                     <div class="card card-shopee border-0 shadow-sm text-center py-4 modo-monitor-card">
                       <span class="modo-monitor-card-label text-uppercase d-block">Shopee</span>

--- a/Master/src/tracking-coletas-resumo.html
+++ b/Master/src/tracking-coletas-resumo.html
@@ -110,7 +110,7 @@
                               <i class="bx bx-calendar"></i>
                               <span id="coletas-resumo-period-label" class="text-truncate">Quinzena anterior</span>
                             </button>
-                            <div class="dropdown-menu dropdown-menu-end p-0" id="coletas-resumo-period-panel" style="min-width: 640px;">
+                            <div class="dropdown-menu dropdown-menu-end p-0 period-panel" id="coletas-resumo-period-panel">
                               <input type="hidden" id="flt-from" />
                               <input type="hidden" id="flt-to" />
                               <div id="coletas-resumo-date-picker-container"></div>
@@ -121,7 +121,7 @@
                               <i class="ri-filter-3-line me-1"></i> Filtros
                               <span id="filtrosContador" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary d-none">0</span>
                             </button>
-                            <div class="dropdown-menu dropdown-menu-end p-3" style="min-width: 280px;">
+                            <div class="dropdown-menu dropdown-menu-end p-3 filter-menu">
                               <div class="mb-2">
                                 <label class="form-label small" data-owner-term="base">Base</label>
                                 <select id="flt-base" class="form-select form-select-sm">
@@ -189,7 +189,7 @@
 
 
                 <!-- 🔹 Tabela -->
-<div class="table-responsive">
+<div class="table-responsive table-card">
   <table id="coletas-resumo-table" class="table table-striped align-middle table-hover">
     <thead class="table-light">
       <tr>
@@ -278,7 +278,7 @@
 
     <!-- Modal Step 1: Selecionar Base (quando base não está filtrada) -->
     <div class="modal fade" id="modalSelecionarBaseFechamento" tabindex="-1" aria-labelledby="modalSelecionarBaseFechamentoLabel" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="modalSelecionarBaseFechamentoLabel">
@@ -307,7 +307,7 @@
 
     <!-- Modal Fechamento de Bases -->
     <div class="modal fade" id="modalFechamentoBases" tabindex="-1" aria-labelledby="modalFechamentoBasesLabel" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered modal-xl">
+      <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-xl">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="modalFechamentoBasesLabel">
@@ -435,7 +435,7 @@
 
     <!-- Modal Coleta Manual -->
     <div class="modal fade" id="modalColetaManual" tabindex="-1" aria-labelledby="modalColetaManualLabel" aria-hidden="true">
-      <div class="modal-dialog">
+      <div class="modal-dialog modal-dialog-scrollable">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="modalColetaManualLabel">Coleta Manual</h5>

--- a/Master/src/tracking-contabilidade.html
+++ b/Master/src/tracking-contabilidade.html
@@ -26,7 +26,7 @@
                           <i class="bx bx-calendar"></i>
                           <span id="contabilidade-period-label" class="text-truncate">Quinzena atual</span>
                         </button>
-                        <div class="dropdown-menu dropdown-menu-end p-0" id="contabilidade-period-panel" style="min-width: 640px;">
+                        <div class="dropdown-menu dropdown-menu-end p-0 period-panel" id="contabilidade-period-panel">
                           <input type="hidden" id="flt-data-inicio" />
                           <input type="hidden" id="flt-data-fim" />
                           <div id="contabilidade-date-picker-container"></div>

--- a/Master/src/tracking-entrada-leitura.html
+++ b/Master/src/tracking-entrada-leitura.html
@@ -120,7 +120,7 @@
                   <p class="text-muted text-uppercase modo-monitor-section-label mb-2">Total de entradas do dia</p>
                   <p id="monitor-total" class="modo-monitor-total-num text-primary mb-0">0</p>
                 </div>
-                <div class="row g-3 g-md-4 w-100 justify-content-center" style="max-width: 1000px;">
+                <div class="row g-3 g-md-4 w-100 justify-content-center" style="max-width: min(1000px, 100%);">
                   <div class="col-4">
                     <div class="card card-shopee border-0 shadow-sm text-center py-4 modo-monitor-card">
                       <span class="modo-monitor-card-label text-uppercase d-block">Shopee</span>

--- a/Master/src/tracking-entregador.html
+++ b/Master/src/tracking-entregador.html
@@ -138,11 +138,11 @@
     @@include("partials/vendor-scripts.html")
 
 <!-- Offcanvas: Formulário -->
-<div class="offcanvas offcanvas-end offcanvas-form"
+<div class="offcanvas offcanvas-end offcanvas-form offcanvas-form--w520"
      tabindex="-1"
      id="oc-form"
      aria-labelledby="ocLabel"
-     style="width:520px"
+     
      data-bs-scroll="false"
      data-bs-backdrop="true">
   <div class="offcanvas-header border-bottom">
@@ -272,7 +272,7 @@
 
     <!-- Modal de exclusão -->
     <div class="modal fade" id="modalDelete" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-body text-center p-4">
             <lord-icon src="https://cdn.lordicon.com/gsqxdxog.json" trigger="loop"

--- a/Master/src/tracking-entregadores-a-pagar.html
+++ b/Master/src/tracking-entregadores-a-pagar.html
@@ -33,7 +33,7 @@
                             <i class="bx bx-calendar"></i>
                             <span id="a-pagar-period-label" class="text-truncate">Quinzena anterior</span>
                           </button>
-                          <div class="dropdown-menu dropdown-menu-end p-0" id="a-pagar-period-panel" style="min-width: 640px;">
+                          <div class="dropdown-menu dropdown-menu-end p-0 period-panel" id="a-pagar-period-panel">
                             <input type="hidden" id="flt-data-inicio" />
                             <input type="hidden" id="flt-data-fim" />
                             <div id="a-pagar-date-picker-container"></div>
@@ -44,7 +44,7 @@
                             <i class="ri-filter-3-line me-1"></i> Filtros
                             <span id="filtrosContador" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary d-none">0</span>
                           </button>
-                          <div class="dropdown-menu dropdown-menu-end p-3" style="min-width: 280px;">
+                          <div class="dropdown-menu dropdown-menu-end p-3 filter-menu">
                             <div class="mb-3">
                               <label class="form-label small">Situação</label>
                               <select id="flt-status" class="form-select form-select-sm">

--- a/Master/src/tracking-entregadores-resumo.html
+++ b/Master/src/tracking-entregadores-resumo.html
@@ -33,7 +33,7 @@
                               <i class="bx bx-calendar"></i>
                               <span id="entregadores-resumo-period-label" class="text-truncate">Quinzena anterior</span>
                             </button>
-                            <div class="dropdown-menu dropdown-menu-end p-0" id="entregadores-resumo-period-panel" style="min-width: 640px;">
+                            <div class="dropdown-menu dropdown-menu-end p-0 period-panel" id="entregadores-resumo-period-panel">
                               <input type="hidden" id="flt-data-inicio" />
                               <input type="hidden" id="flt-data-fim" />
                               <div id="entregadores-resumo-date-picker-container"></div>
@@ -44,7 +44,7 @@
                               <i class="ri-filter-3-line me-1"></i> Filtros
                               <span id="filtrosContador" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary d-none">0</span>
                             </button>
-                            <div class="dropdown-menu dropdown-menu-end p-3" style="min-width: 280px;">
+                            <div class="dropdown-menu dropdown-menu-end p-3 filter-menu">
                               <div class="mb-2">
                                 <label class="form-label small">Motoboy</label>
                                 <select id="flt-entregador" class="form-select form-select-sm">
@@ -73,7 +73,7 @@
                     </div>
                     <div id="resumoMsg" class="mb-3"></div>
                     <!-- Cards totalizadores (mesma linha, como Registros) -->
-                    <div class="row g-2 mb-3 flex-nowrap">
+                    <div class="row g-2 mb-3 flex-nowrap kpi-row">
                       <div class="col flex-fill" style="min-width: 0;">
                         <div class="p-3 rounded text-center card-er-flex">
                           <span class="text-uppercase small text-secondary fw-semibold d-block">Flex</span>
@@ -159,7 +159,7 @@
 
     <!-- Modal Fechamento -->
     <div class="modal fade" id="modalFechamento" tabindex="-1" aria-labelledby="modalFechamentoLabel" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-lg">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="modalFechamentoLabel">

--- a/Master/src/tracking-etiquetas.html
+++ b/Master/src/tracking-etiquetas.html
@@ -40,7 +40,7 @@
             <div class="card-body">
               <iframe
                 id="preview-iframe"
-                style="width:100%; height:600px; border:1px solid #dee2e6; border-radius:4px;"
+                class="etiquetas-preview-frame"
               ></iframe>
             </div>
           </div>

--- a/Master/src/tracking-leitura.html
+++ b/Master/src/tracking-leitura.html
@@ -145,7 +145,7 @@
                   <p class="text-muted text-uppercase modo-monitor-section-label mb-2">Total de leituras</p>
                   <p id="monitor-total" class="modo-monitor-total-num text-primary mb-0">0</p>
                 </div>
-                <div class="row g-3 g-md-4 w-100 justify-content-center" style="max-width: 1000px;">
+                <div class="row g-3 g-md-4 w-100 justify-content-center" style="max-width: min(1000px, 100%);">
                   <div class="col-4">
                     <div class="card card-shopee border-0 shadow-sm text-center py-4 modo-monitor-card">
                       <span class="modo-monitor-card-label text-uppercase d-block">Shopee</span>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -46,7 +46,7 @@
                       <i class="bx bx-calendar"></i>
                       <span id="registros-period-label" class="text-truncate">Hoje - 15 dias</span>
                     </button>
-                    <div class="dropdown-menu dropdown-menu-end p-0" id="registros-period-panel" style="min-width: 640px;">
+                    <div class="dropdown-menu dropdown-menu-end p-0 period-panel" id="registros-period-panel">
                       <input type="hidden" id="flt-from" />
                       <input type="hidden" id="flt-to" />
                       <div id="registros-date-picker-container"></div>
@@ -57,7 +57,7 @@
                       <i class="ri-filter-3-line me-1"></i> Filtros
                       <span id="filtrosContador" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary d-none">0</span>
                     </button>
-                    <div class="dropdown-menu dropdown-menu-end p-3" style="min-width: 280px;">
+                    <div class="dropdown-menu dropdown-menu-end p-3 filter-menu">
                       <div class="mb-2">
                         <label class="form-label small" data-owner-term="base">Base</label>
                         <select id="flt-base" class="form-select form-select-sm">
@@ -357,7 +357,7 @@
                     <span class="small fw-semibold">Carregando registros...</span>
                   </div>
                 </div>
-              <div class="table-responsive">
+              <div class="table-responsive table-card">
                 <table class="table align-middle table-nowrap">
                   <thead class="table-active">
                     <tr>
@@ -369,9 +369,9 @@
                       <th style="min-width:160px;">Última ação</th>
                       <th style="min-width:150px;">Motoboy</th>
                       <th style="min-width:160px;">Horário da ação</th>
-                      <th style="min-width:170px;">Entrada no sistema</th>
-                      <th style="min-width:110px;">Executado por</th>
-                      <th style="min-width:110px;">Seller</th>
+                      <th class="d-none d-xl-table-cell" style="min-width:170px;">Entrada no sistema</th>
+                      <th class="d-none d-xl-table-cell" style="min-width:110px;">Executado por</th>
+                      <th class="d-none d-xl-table-cell" style="min-width:110px;">Seller</th>
                       <th class="text-center" style="width:50px" title="Pacote G (Grande)">G</th>
                     </tr>
                   </thead>
@@ -449,7 +449,7 @@
 
       <!-- Modal Editar (singular) -->
 <div class="modal fade" id="editModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog"><div class="modal-content">
+  <div class="modal-dialog modal-dialog-scrollable"><div class="modal-content">
     <div class="modal-header p-3 bg-success-subtle">
       <h5 class="modal-title">Editar Registro</h5>
       <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
@@ -592,9 +592,9 @@
   .pedido-detail-container { padding: 20px; background: #f8fafc; }
   .pedido-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
   .pedido-codigo { font-size: 20px; font-weight: 600; }
-  .pedido-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 15px; }
+  .pedido-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr)); gap: 15px; }
   .pedido-grid-2 { grid-template-columns: minmax(260px, 0.9fr) minmax(320px, 1.1fr); }
-  @media (max-width: 900px) {
+  @media (max-width: 1199.98px) {
     .pedido-grid-2 { grid-template-columns: 1fr; }
   }
   .pedido-card { background: #ffffff; border-radius: 8px; padding: 15px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); }
@@ -679,7 +679,7 @@
 </style>
 
 <div class="modal fade" id="bulkModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
     <div class="modal-content border-0 shadow-lg">
       <div class="modal-header bg-primary-subtle border-0">
         <h5 id="bulk-title" class="modal-title fw-semibold text-primary-emphasis">Editar registros em lote</h5>

--- a/Master/src/tracking-usuarios.html
+++ b/Master/src/tracking-usuarios.html
@@ -236,8 +236,8 @@
 </style>
 
 <!-- ===================== OFFCANVAS (CREATE/EDIT) ===================== -->
-<div class="offcanvas offcanvas-end offcanvas-form" tabindex="-1" id="oc-user" aria-labelledby="ocLabel"
-     style="width:900px; display: flex; flex-direction: column;" data-bs-backdrop="true">
+<div class="offcanvas offcanvas-end offcanvas-form offcanvas-form--w900" tabindex="-1" id="oc-user" aria-labelledby="ocLabel"
+     style="display: flex; flex-direction: column;" data-bs-backdrop="true">
 
     <div class="offcanvas-header border-bottom flex-shrink-0">
         <h5 class="offcanvas-title" id="ocLabel">Novo Usuário</h5>

--- a/Master/src/tracking-valores-entrega.html
+++ b/Master/src/tracking-valores-entrega.html
@@ -130,8 +130,8 @@
     @@include("partials/vendor-scripts.html")
 
     <!-- Offcanvas: Editar Valores Globais -->
-    <div class="offcanvas offcanvas-end offcanvas-form" tabindex="-1" id="oc-global" aria-labelledby="ocGlobalLabel"
-      style="width:400px" data-bs-scroll="false" data-bs-backdrop="true">
+    <div class="offcanvas offcanvas-end offcanvas-form offcanvas-form--w400" tabindex="-1" id="oc-global" aria-labelledby="ocGlobalLabel"
+      data-bs-scroll="false" data-bs-backdrop="true">
       <div class="offcanvas-header border-bottom">
         <h5 class="offcanvas-title" id="ocGlobalLabel">Editar Valores Globais</h5>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
@@ -179,8 +179,8 @@
     </div>
 
     <!-- Offcanvas: Adicionar/Editar Exceção -->
-    <div class="offcanvas offcanvas-end offcanvas-form" tabindex="-1" id="oc-excecao" aria-labelledby="ocExcecaoLabel"
-      style="width:480px" data-bs-scroll="false" data-bs-backdrop="true">
+    <div class="offcanvas offcanvas-end offcanvas-form offcanvas-form--w480" tabindex="-1" id="oc-excecao" aria-labelledby="ocExcecaoLabel"
+       data-bs-scroll="false" data-bs-backdrop="true">
       <div class="offcanvas-header border-bottom">
         <h5 class="offcanvas-title" id="ocExcecaoLabel">Adicionar Exceção</h5>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
@@ -226,7 +226,7 @@
 
     <!-- Modal de exclusão -->
     <div class="modal fade" id="modalDelete" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-body text-center p-4">
             <lord-icon src="https://cdn.lordicon.com/gsqxdxog.json" trigger="loop"


### PR DESCRIPTION
## Resumo

Torna o frontend Master estável em monitores 1280–1920 e zoom 100–150%, com utilitários CSS compartilhados e ajustes nas telas/janelas do produto (period panels, offcanvas, tabelas, KPIs, modais, dashboards e scanner).

## Tipo de alteração

- [ ] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Utilitários fluidos em `custom.scss` (`.period-panel`, `.period-panel-sm`, `.filter-menu`, `.offcanvas-form`, `.kpi-row`, `.table-card`, modais, charts, scanner)
- Sidebar auto-compacta em viewport estreita (`layout.js`: `md` &lt;1200, `sm` &lt;992)
- Migração dos 10 period panels (incluindo `#a-pagar-period-panel`) e offcanvas de cadastro para larguras fluidas
- Tabelas/KPIs/modais densos + colunas secundárias de Registros ocultas abaixo de `xl`
- Ajustes em dashboards, leituras/scanner, avisos, etiquetas, perfil e autenticação

## Como testar

- Rebuild SCSS (`npx gulp scss` em `Master/`) se necessário
- Abrir fluxos: Login → Dashboard → Registros (período + detalhe) → Acompanhamento → Usuários (offcanvas) → Entregadores/A pagar → Coletas → Contabilidade → Leitura/scanner → Avisos/Etiquetas → Perfil
- Validar em 1920@100%, 1366@125%, 1366@150%, 1280 com sidebar; altura baixa no scanner

## Impacto

- [ ] Sem impacto em produção
- [ ] Altera comportamento existente
- [x] Altera layout/interface
- [ ] Altera integração com backend/API
- [ ] Requer configuração adicional
- [ ] Requer atualização em outro repositório

## Checklist

- [x] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Objetivo

Estabilizar layout do web em monitores estreitos e zoom alto, sem mudar regra de negócio nem contrato de API.

## Rollback

Reverter o merge desta PR / commit `a2555a7e`.

Made with [Cursor](https://cursor.com)