### PR TITLE
fix: unifica nomenclatura Base/Seller conforme tipo do owner

### DIFF
--- a/Master/src/assets/js/pages/dashboard-coletas.init.js
+++ b/Master/src/assets/js/pages/dashboard-coletas.init.js
@@ -222,7 +222,7 @@
       },
       legend: { data: ["Com coletas", "Sem coletas"], bottom: 0 },
       xAxis: { type: "category", data: dates },
-      yAxis: { type: "value", name: "Bases" },
+      yAxis: { type: "value", name: typeof window.ownerTerm === "function" ? window.ownerTerm("bases") : "Bases" },
       series: [
         { name: "Com coletas", type: "bar", data: comColetas, itemStyle: { color: "#0d6efd" } },
         { name: "Sem coletas", type: "bar", data: semColetas, itemStyle: { color: "#dc3545" } }
@@ -252,7 +252,7 @@
       var bases = c.bases_sem_coletas_lista || [];
       modalBody.innerHTML = bases.length > 0
         ? "<ul class='mb-0'>" + bases.map(function (b) { return "<li>" + escapeHtml(b) + "</li>"; }).join("") + "</ul>"
-        : "<p class='text-muted mb-0'>Nenhuma base sem coletas no período.</p>";
+        : "<p class='text-muted mb-0'>" + (typeof window.ownerTerm === "function" ? window.ownerTerm("nenhuma_base_sem_coletas") : "Nenhuma base sem coletas no período.") + "</p>";
     }
   }
 
@@ -413,16 +413,16 @@
       ["Total Coletas", c.total_coletas],
       ["Valor Total", formatMoeda(c.valor_total)],
       ["Cancelados", c.cancelados, "Taxa: " + (c.taxa_cancelamento || 0) + "%"],
-      ["Bases ativas (total)", c.bases_total_ativas ?? 0],
-      ["Bases com coletas", c.bases_com_coletas],
-      ["Bases sem coletas", c.bases_sem_coletas],
+      [(typeof window.ownerTerm === "function" ? window.ownerTerm("bases") : "Bases") + " ativas (total)", c.bases_total_ativas ?? 0],
+      [(typeof window.ownerTerm === "function" ? window.ownerTerm("bases") : "Bases") + " com coletas", c.bases_com_coletas],
+      [(typeof window.ownerTerm === "function" ? window.ownerTerm("bases") : "Bases") + " sem coletas", c.bases_sem_coletas],
       [],
       ["Shopee", c.shopee, formatMoeda(c.valor_shopee)],
       ["Mercado Livre", c.mercado_livre, formatMoeda(c.valor_mercado_livre)],
       ["Avulso", c.avulso, formatMoeda(c.valor_avulso)],
       [],
-      ["Ranking por Base"],
-      ["Base", "Coletas", "%", "Valor", "Variação"]
+      [typeof window.ownerTerm === "function" ? window.ownerTerm("ranking_por_base") : "Ranking por Base"],
+      [typeof window.ownerTerm === "function" ? window.ownerTerm("base") : "Base", "Coletas", "%", "Valor", "Variação"]
     ];
     (data.ranking_bases || []).forEach(function (r) {
       rows.push([r.nome, r.coletas, r.pct_total + "%", formatMoeda(r.valor_total), r.variacao_pct != null ? r.variacao_pct + "%" : "—"]);

--- a/Master/src/assets/js/pages/dashboard-visao-360.init.js
+++ b/Master/src/assets/js/pages/dashboard-visao-360.init.js
@@ -300,7 +300,7 @@
     var baseSel = document.getElementById("fifo-filtro-base");
     var mpSel = document.getElementById("fifo-filtro-marketplace");
     if (baseSel) {
-      var opts = "<option value=''>Todas as bases</option>";
+      var opts = "<option value=''>" + (typeof window.ownerTerm === "function" ? window.ownerTerm("todas_as_bases") : "Todas as bases") + "</option>";
       Object.keys(bases).sort().forEach(function (b) { opts += "<option value='" + escapeHtml(b) + "'>" + escapeHtml(b) + "</option>"; });
       baseSel.innerHTML = opts;
     }

--- a/Master/src/assets/js/pages/owner-labels.init.js
+++ b/Master/src/assets/js/pages/owner-labels.init.js
@@ -1,7 +1,7 @@
 /**
  * Aplica labels Base/Seller conforme tipo do owner (window.TIPO_OWNER).
- * Elementos com data-owner-term são atualizados: base, bases, fechamento_base, etc.
- * Deve rodar após user.js ter carregado __USER__ (ou quando aplicável).
+ * Elementos com data-owner-term são atualizados.
+ * Use window.ownerTerm("chave") em JS dinâmico (toasts, modais, PDF).
  */
 (function () {
   "use strict";
@@ -9,21 +9,169 @@
   var LABELS = {
     base: { subbase: "Base", base: "Seller" },
     bases: { subbase: "Bases", base: "Sellers" },
+    base_lower: { subbase: "base", base: "seller" },
+    bases_lower: { subbase: "bases", base: "sellers" },
+    a_base: { subbase: "a Base", base: "o Seller" },
+    a_base_lower: { subbase: "a base", base: "o seller" },
+    da_base: { subbase: "da Base", base: "do Seller" },
+    da_base_lower: { subbase: "da base", base: "do seller" },
+    uma_base: { subbase: "uma Base", base: "um Seller" },
+    uma_base_lower: { subbase: "uma base", base: "um seller" },
+    as_bases_lower: { subbase: "as bases", base: "os sellers" },
+    esta_base_lower: { subbase: "esta base", base: "este seller" },
     fechamento_base: { subbase: "Fechamento de Bases", base: "Fechamento Seller" },
+    fechamento_de_base: { subbase: "Fechamento de Base", base: "Fechamento Seller" },
     nova_base: { subbase: "Nova Base", base: "Novo Seller" },
+    editar_base: { subbase: "Editar Base", base: "Editar Seller" },
     dados_da_base: { subbase: "Dados da Base", base: "Dados do Seller" },
+    dados_da_base_selecionada: { subbase: "Dados da Base selecionada", base: "Dados do Seller selecionado" },
+    selecione_detalhe: {
+      subbase: "Selecione uma Base na lista acima para ver os detalhes de CNPJ e endereço.",
+      base: "Selecione um Seller na lista acima para ver os detalhes de CNPJ e endereço.",
+    },
+    sem_dados_detalhe: {
+      subbase: "Não há dados de CNPJ e endereço cadastrados para a Base selecionada.",
+      base: "Não há dados de CNPJ e endereço cadastrados para o Seller selecionado.",
+    },
     nome_da_base: { subbase: "Nome da Base", base: "Nome do Seller" },
     selecione_a_base: { subbase: "Selecione a Base", base: "Selecione o Seller" },
+    selecione_uma_base: { subbase: "Selecione uma Base", base: "Selecione um Seller" },
+    selecione_a_base_fechamento: {
+      subbase: "Selecione a base para gerar o fechamento.",
+      base: "Selecione o seller para gerar o fechamento.",
+    },
     base_obrigatoria: { subbase: "Base obrigatória", base: "Seller obrigatório" },
     selecionar_base: { subbase: "Selecionar Base", base: "Selecionar Seller" },
     passo1_selecionar_base: { subbase: "Passo 1 — Selecionar Base", base: "Passo 1 — Selecionar Seller" },
     gerar_fechamento_base: { subbase: "Gerar Fechamento de Base", base: "Gerar Fechamento Seller" },
+    reajustar_fechamento_base: { subbase: "Reajustar Fechamento de Base", base: "Reajustar Fechamento Seller" },
     excluir_base: { subbase: "Excluir base?", base: "Excluir seller?" },
+    buscar_por_base: { subbase: "Buscar por base...", base: "Buscar por seller..." },
+    buscar_codigo_entregador_base: {
+      subbase: "Buscar por código, entregador ou base...",
+      base: "Buscar por código, entregador ou seller...",
+    },
+    nenhuma_base_encontrada: { subbase: "Nenhuma base encontrada.", base: "Nenhum seller encontrado." },
+    nenhuma_base_ativa: {
+      subbase: "Nenhuma base ativa cadastrada. Cadastre uma base para registrar coletas.",
+      base: "Nenhum seller ativo cadastrado. Cadastre um seller para registrar coletas.",
+    },
+    informe_nome_base: { subbase: "Informe o nome da base.", base: "Informe o nome do seller." },
+    cnpj_da_entidade: { subbase: "CNPJ da Base", base: "CNPJ do Seller" },
+    cnpj_help_owner_base: {
+      subbase: "Obrigatório quando o Owner for do tipo Base (Seller).",
+      base: "Obrigatório para Owner do tipo Base (Seller).",
+    },
+    cep_help_entidade: {
+      subbase: "Digite o CEP e saia do campo para preencher automaticamente (obrigatório para a Base).",
+      base: "Digite o CEP e saia do campo para preencher automaticamente (obrigatório para o Seller).",
+    },
+    bases_ativas: { subbase: "Bases Ativas", base: "Sellers Ativos" },
+    bases_com_sem_coletas: { subbase: "Bases com e sem coletas por dia", base: "Sellers com e sem coletas por dia" },
+    bases_sem_coletas: { subbase: "Bases sem coletas registradas", base: "Sellers sem coletas registradas" },
+    ver_bases_sem_coletas: { subbase: "Ver bases sem coletas", base: "Ver sellers sem coletas" },
+    ver_bases_sem_coletas_dia: { subbase: "Ver bases sem coletas por dia", base: "Ver sellers sem coletas por dia" },
+    ranking_por_base: { subbase: "Ranking por Base", base: "Ranking por Seller" },
+    ranking_por_base_cliente: { subbase: "Ranking por Base/Cliente", base: "Ranking por Seller" },
+    volume_coletas_por_base: { subbase: "Volume de coletas registradas por base", base: "Volume de coletas registradas por seller" },
+    ganho_por_base: { subbase: "Ganho por Base", base: "Ganho por Seller" },
+    rentabilidade_por_base: { subbase: "Rentabilidade por Base", base: "Rentabilidade por Seller" },
+    ranking_bases_lucro: {
+      subbase: "Ranking de bases ordenado por lucro líquido",
+      base: "Ranking de sellers ordenado por lucro líquido",
+    },
+    todas_as_bases: { subbase: "Todas as bases", base: "Todos os sellers" },
+    nenhuma_base_periodo: { subbase: "Nenhuma base no período.", base: "Nenhum seller no período." },
+    nenhuma_base_sem_coletas: {
+      subbase: "Nenhuma base sem coletas no período.",
+      base: "Nenhum seller sem coletas no período.",
+    },
+    ja_existe_nome: {
+      subbase: "Já existe uma base com esse nome nesta sub-base.",
+      base: "Já existe um seller com esse nome nesta sub-base.",
+    },
+    base_atualizada: { subbase: "Base atualizada com sucesso.", base: "Seller atualizado com sucesso." },
+    base_criada: { subbase: "Base criada com sucesso.", base: "Seller criado com sucesso." },
+    selecione_base_antes_registrar: {
+      subbase: "Selecione a base antes de registrar.",
+      base: "Selecione o seller antes de registrar.",
+    },
+    selecione_base_antes_reenviar: {
+      subbase: "Selecione uma base antes de reenviar.",
+      base: "Selecione um seller antes de reenviar.",
+    },
+    selecione_a_base_toast: { subbase: "Selecione a base", base: "Selecione o seller" },
+    selecione_base_inatividade: {
+      subbase: "Selecione a base novamente (inatividade).",
+      base: "Selecione o seller novamente (inatividade).",
+    },
+    falha_carregar_bases: { subbase: "Falha ao carregar bases.", base: "Falha ao carregar sellers." },
+    erro_carregar_bases: { subbase: "Erro ao carregar bases.", base: "Erro ao carregar sellers." },
+    informe_a_base: { subbase: "É necessário informar a base.", base: "É necessário informar o seller." },
+    selecione_uma_base_toast: { subbase: "Selecione uma base.", base: "Selecione um seller." },
+    selecione_uma_base_validator: { subbase: "Selecione uma base", base: "Selecione um seller" },
+    ja_existe_fechamento: {
+      subbase: "Já existe um fechamento gerado para esta base e período. Deseja reajustar?",
+      base: "Já existe um fechamento gerado para este seller e período. Deseja reajustar?",
+    },
+    ha_mais_de_uma_base: {
+      subbase: "Há mais de uma base com fechamento GERADO. Escolha qual deseja reajustar.",
+      base: "Há mais de um seller com fechamento GERADO. Escolha qual deseja reajustar.",
+    },
+    reajustar_selecione: { subbase: "Reajustar: selecione a base", base: "Reajustar: selecione o seller" },
+    escolha_base_cobranca: {
+      subbase: "Para gerar a cobrança, escolha uma base específica.",
+      base: "Para gerar a cobrança, escolha um seller específico.",
+    },
+    cnpj_obrigatorio_entidade: { subbase: "CNPJ é obrigatório para a Base.", base: "CNPJ é obrigatório para o Seller." },
+    cep_obrigatorio_entidade: {
+      subbase: "CEP é obrigatório e deve ter 8 dígitos para a Base.",
+      base: "CEP é obrigatório e deve ter 8 dígitos para o Seller.",
+    },
+    rua_obrigatoria_entidade: { subbase: "Rua é obrigatória para a Base.", base: "Rua é obrigatória para o Seller." },
+    numero_obrigatorio_entidade: { subbase: "Número é obrigatório para a Base.", base: "Número é obrigatório para o Seller." },
+    bairro_obrigatorio_entidade: { subbase: "Bairro é obrigatório para a Base.", base: "Bairro é obrigatório para o Seller." },
+    cidade_obrigatoria_entidade: { subbase: "Cidade é obrigatória para a Base.", base: "Cidade é obrigatória para o Seller." },
+    falha_salvar_dados: { subbase: "Falha ao salvar dados da Base.", base: "Falha ao salvar dados do Seller." },
+    base_obrigatoria_nao_coletado: {
+      subbase: "Base obrigatória para 'Não Coletado'.",
+      base: "Seller obrigatório para 'Não Coletado'.",
+    },
+    lancamento_mesma_data_base: {
+      subbase: "Já existe um lançamento para essa mesma data e base. Use Editar no registro existente.",
+      base: "Já existe um lançamento para essa mesma data e seller. Use Editar no registro existente.",
+    },
+  };
+
+  var TITLE_MAP = {
+    subbase: {
+      Sellers: "Bases",
+      "Fechamento Seller": "Fechamento de Bases",
+    },
+    base: {
+      Bases: "Sellers",
+      "Fechamento de Bases": "Fechamento Seller",
+    },
   };
 
   function getTipo() {
-    var t = (window.TIPO_OWNER || (window.__USER__ && window.__USER__.tipo_owner) || "subbase");
+    var t = window.TIPO_OWNER || (window.__USER__ && window.__USER__.tipo_owner) || "subbase";
     return (t + "").toLowerCase() === "base" ? "base" : "subbase";
+  }
+
+  function ownerTerm(term, fallback) {
+    var labels = LABELS[(term || "").trim().toLowerCase()];
+    if (!labels) return fallback != null ? fallback : term;
+    var text = labels[getTipo()];
+    return text != null ? text : fallback != null ? fallback : term;
+  }
+
+  function applyDocumentTitle() {
+    var raw = document.title || "";
+    var suffix = " | Tracking Saídas";
+    var main = raw.endsWith(suffix) ? raw.slice(0, -suffix.length) : raw;
+    var mapped = TITLE_MAP[getTipo()][main];
+    if (mapped) document.title = mapped + suffix;
   }
 
   function applyOwnerLabels() {
@@ -34,11 +182,30 @@
       var labels = LABELS[term];
       if (!labels) return;
       var text = labels[tipo];
-      if (text !== undefined) el.textContent = text;
+      if (text === undefined) return;
+      var attr = (el.getAttribute("data-owner-attr") || "").trim().toLowerCase();
+      if (el.tagName === "TITLE") {
+        document.title = text + " | Tracking Saídas";
+        return;
+      }
+      if (attr === "placeholder" || (!attr && (el.tagName === "INPUT" || el.tagName === "TEXTAREA"))) {
+        el.setAttribute("placeholder", text);
+        return;
+      }
+      if (attr && attr !== "text") {
+        el.setAttribute(attr, text);
+        return;
+      }
+      el.textContent = text;
     });
+    applyDocumentTitle();
   }
 
+  window.ownerTerm = ownerTerm;
   window.applyOwnerLabels = applyOwnerLabels;
+  window.isOwnerTipoBase = function () {
+    return getTipo() === "base";
+  };
 
   document.addEventListener("DOMContentLoaded", function () {
     applyOwnerLabels();

--- a/Master/src/assets/js/pages/tracking-base.init.js
+++ b/Master/src/assets/js/pages/tracking-base.init.js
@@ -140,7 +140,7 @@ async function apiCreate(payload) {
     });
   } catch (err) {
     if (err.status === 409) {
-      toast("Já existe uma base com esse nome nesta sub-base.", false);
+      toast(typeof window.ownerTerm === "function" ? window.ownerTerm("ja_existe_nome") : "Já existe uma base com esse nome nesta sub-base.", false);
       throw err;
     }
     throw err;
@@ -158,7 +158,7 @@ async function apiUpdate(id, payload) {
     });
   } catch (err) {
     if (err.status === 409) {
-      toast("Já existe uma base com esse nome nesta sub-base.", false);
+      toast(typeof window.ownerTerm === "function" ? window.ownerTerm("ja_existe_nome") : "Já existe uma base com esse nome nesta sub-base.", false);
       throw err;
     }
     throw err;
@@ -265,7 +265,9 @@ async function apiDelete(id) {
       if (typeof message === "string" && message.trim()) {
         empty.textContent = message;
       } else {
-        empty.textContent = "Selecione um Seller na lista acima para ver os detalhes de CNPJ e endereço.";
+        empty.textContent = typeof window.ownerTerm === "function"
+          ? window.ownerTerm("selecione_detalhe")
+          : "Selecione uma Base na lista acima para ver os detalhes de CNPJ e endereço.";
       }
     }
     if (content) content.classList.add("d-none");
@@ -317,13 +319,13 @@ async function apiDelete(id) {
         `${API_URL}/owner/${encodeURIComponent(OWNER_INFO.id_owner)}/seller-dados?base_id=${encodeURIComponent(SELECTED_ID)}`
       );
       if (!seller) {
-        showSellerDetailEmpty("Não há dados de CNPJ e endereço cadastrados para o Seller selecionado.");
+        showSellerDetailEmpty(typeof window.ownerTerm === "function" ? window.ownerTerm("sem_dados_detalhe") : "Não há dados de CNPJ e endereço cadastrados para a Base selecionada.");
         return;
       }
       renderSellerDetail(seller);
     } catch (err) {
-      // 404 ou outro erro → indica ausência de dados para o seller selecionado
-      showSellerDetailEmpty("Não há dados de CNPJ e endereço cadastrados para o Seller selecionado.");
+      // 404 ou outro erro → indica ausência de dados para a entidade selecionada
+      showSellerDetailEmpty(typeof window.ownerTerm === "function" ? window.ownerTerm("sem_dados_detalhe") : "Não há dados de CNPJ e endereço cadastrados para a Base selecionada.");
     }
   }
 
@@ -402,7 +404,7 @@ async function apiDelete(id) {
       showSellerDetailEmpty();
     } catch (err) {
       console.error(err);
-      toast("Falha ao carregar bases.", false);
+      toast(typeof window.ownerTerm === "function" ? window.ownerTerm("falha_carregar_bases") : "Falha ao carregar bases.", false);
     }
   }
 
@@ -410,7 +412,9 @@ async function apiDelete(id) {
     const form = qs("#formBase");
     form.reset();
     form.classList.remove("was-validated");
-    qs("#ocLabel").textContent = modo === "edit" ? "Editar Base" : "Nova Base";
+    qs("#ocLabel").textContent = modo === "edit"
+      ? (typeof window.ownerTerm === "function" ? window.ownerTerm("editar_base") : "Editar Base")
+      : (typeof window.ownerTerm === "function" ? window.ownerTerm("nova_base") : "Nova Base");
 
     qs("#baseId").value = data?.id_base || "";
     qs("#base").value = data?.base || "";
@@ -612,12 +616,13 @@ async function apiDelete(id) {
 
       const errosSeller = [];
       if (ownerTipo === "base") {
-        if (!cnpjDig) errosSeller.push("CNPJ é obrigatório para Seller/Base.");
-        if (cepDig.length !== 8) errosSeller.push("CEP é obrigatório e deve ter 8 dígitos para Seller/Base.");
-        if (!rua) errosSeller.push("Rua é obrigatória para Seller/Base.");
-        if (!numero) errosSeller.push("Número é obrigatório para Seller/Base.");
-        if (!bairro) errosSeller.push("Bairro é obrigatório para Seller/Base.");
-        if (!cidade) errosSeller.push("Cidade é obrigatória para Seller/Base.");
+        const ot = (k) => (typeof window.ownerTerm === "function" ? window.ownerTerm(k) : k);
+        if (!cnpjDig) errosSeller.push(ot("cnpj_obrigatorio_entidade"));
+        if (cepDig.length !== 8) errosSeller.push(ot("cep_obrigatorio_entidade"));
+        if (!rua) errosSeller.push(ot("rua_obrigatoria_entidade"));
+        if (!numero) errosSeller.push(ot("numero_obrigatorio_entidade"));
+        if (!bairro) errosSeller.push(ot("bairro_obrigatorio_entidade"));
+        if (!cidade) errosSeller.push(ot("cidade_obrigatoria_entidade"));
       }
 
       if (errosSeller.length) {
@@ -657,13 +662,15 @@ async function apiDelete(id) {
           });
           if (!rSeller.ok) {
             const errBody = await rSeller.json().catch(() => ({}));
-            const msg = errBody.detail || errBody.message || "Falha ao salvar dados do Seller/Base.";
+            const msg = errBody.detail || errBody.message || (typeof window.ownerTerm === "function" ? window.ownerTerm("falha_salvar_dados") : "Falha ao salvar dados da Base.");
             toast(msg, false);
             return;
           }
         }
 
-        toast(id ? "Base atualizada com sucesso." : "Base criada com sucesso.");
+        toast(id
+          ? (typeof window.ownerTerm === "function" ? window.ownerTerm("base_atualizada") : "Base atualizada com sucesso.")
+          : (typeof window.ownerTerm === "function" ? window.ownerTerm("base_criada") : "Base criada com sucesso."));
         offcanvas.hide();
         await listarBases();
       } catch (err) {

--- a/Master/src/assets/js/pages/tracking-coleta-leitura.init.js
+++ b/Master/src/assets/js/pages/tracking-coleta-leitura.init.js
@@ -161,7 +161,8 @@ async function carregarBases() {
   }
   const r = await fetch(url, { credentials: "include" });
   if (!r.ok) {
-    const msg = r.status === 401 ? "Faça login para carregar as bases." : (r.status === 403 ? "Sem permissão para listar bases." : `Falha ao carregar bases (${r.status}).`);
+    const entidade = typeof window.ownerTerm === "function" ? window.ownerTerm("bases_lower") : "bases";
+    const msg = r.status === 401 ? `Faça login para carregar ${entidade}.` : (r.status === 403 ? `Sem permissão para listar ${entidade}.` : `Falha ao carregar ${entidade} (${r.status}).`);
     throw new Error(msg);
   }
   const data = await r.json();
@@ -560,7 +561,7 @@ function registrarCodigo() {
   const baseSel = qs("#selBase")?.value;
   const codRaw = qs("#codigo")?.value;
 
-  if (!baseSel) return toast("Selecione a base antes de registrar.", false);
+  if (!baseSel) return toast(typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_base_antes_registrar") : "Selecione a base antes de registrar.", false);
   if (!codRaw) return toast("Informe ou escaneie um código.", false);
 
   const parsed = classifyCodigo(codRaw);
@@ -629,7 +630,7 @@ enviarColetaUnica(novoItem, entId);
 
 /* 🆕 Reenvio manual dos pendentes */
 async function reenviarPendentes() {
-  if (!BASE_ATUAL) return toast("Selecione uma base antes de reenviar.", false);
+  if (!BASE_ATUAL) return toast(typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_base_antes_reenviar") : "Selecione uma base antes de reenviar.", false);
 
   const pendentes = COLETAS.filter(c => ["pendente", "erro"].includes(c.status));
   if (!pendentes.length)
@@ -684,10 +685,10 @@ document.addEventListener("DOMContentLoaded", async () => {
       '<option value="" disabled selected>Selecione...</option>' +
       list.map(b => `<option value="${(b.base != null ? b.base : b).toString()}">${(b.base != null ? b.base : b).toString()}</option>`).join("");
     if (list.length === 0) {
-      toast("Nenhuma base ativa cadastrada. Cadastre uma base para registrar coletas.", false);
+      toast(typeof window.ownerTerm === "function" ? window.ownerTerm("nenhuma_base_ativa") : "Nenhuma base ativa cadastrada. Cadastre uma base para registrar coletas.", false);
     }
   } catch (err) {
-    const msg = err && err.message ? err.message : "Falha ao carregar bases.";
+    const msg = err && err.message ? err.message : (typeof window.ownerTerm === "function" ? window.ownerTerm("falha_carregar_bases") : "Falha ao carregar bases.");
     toast(msg, false);
     sel.innerHTML = '<option value="" disabled selected>Selecione...</option>';
   }
@@ -1002,7 +1003,7 @@ if (res?.sucesso) {
 
     const baseSel = qs("#selBase")?.value;
     if (!baseSel) {
-      showMsg("alerta", "Selecione a base");
+      showMsg("alerta", typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_a_base_toast") : "Selecione a base");
       Sound.play("warn");
       scanLocked = false;
       return;
@@ -1063,7 +1064,7 @@ if (duplicado) {
         BASE_ATUAL = null;
         STORAGE_KEY = null;
 
-        toast("Selecione a base novamente (inatividade).", false);
+        toast(typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_base_inatividade") : "Selecione a base novamente (inatividade).", false);
         console.warn("⏳ Base resetada por inatividade");
       }
     }, TEMPO_INATIVIDADE_MS);

--- a/Master/src/assets/js/pages/tracking-coletas-relatorio.js
+++ b/Master/src/assets/js/pages/tracking-coletas-relatorio.js
@@ -18,8 +18,8 @@ async function gerarPdfResumoColetas(resumo, base, de, ate) {
   if (!base || base.trim() === "") {
     Swal.fire({
       icon: "warning",
-      title: "Selecione uma Base",
-      text: "Para gerar a cobrança, escolha uma base específica."
+      title: typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_uma_base") : "Selecione uma Base",
+      text: typeof window.ownerTerm === "function" ? window.ownerTerm("escolha_base_cobranca") : "Para gerar a cobrança, escolha uma base específica."
     });
     return;
   }
@@ -47,7 +47,8 @@ async function gerarPdfResumoColetas(resumo, base, de, ate) {
      HEADER DO RELATÓRIO
   ====================================================== */
   doc.setFontSize(15);
-  doc.text(`RELATÓRIO DE COLETAS — ${base}`, 105, 20, { align: "center" });
+  const entidadePdf = typeof window.ownerTerm === "function" ? window.ownerTerm("base") : "Base";
+  doc.text(`RELATÓRIO DE COLETAS — ${entidadePdf}: ${base}`, 105, 20, { align: "center" });
 
   doc.setFontSize(10);
   doc.text(
@@ -461,7 +462,7 @@ async function gerarPdfFechamentoBases(idFechamento) {
     doc.rect(marginLeft, boxTop, boxWidth, contentH, "FD");
     let cursorY = boxTop + paddingBox;
     doc.setFont(undefined, "bold");
-    doc.text("Empresa:", marginLeft + paddingBox, cursorY);
+    doc.text((typeof window.ownerTerm === "function" ? window.ownerTerm("base") : "Base") + ":", marginLeft + paddingBox, cursorY);
     doc.setFont(undefined, "normal");
     doc.text(nomeEmpresa || base || "—", marginLeft + paddingBox + 22, cursorY);
     cursorY += lineH;

--- a/Master/src/assets/js/pages/tracking-coletas-resumo.init.js
+++ b/Master/src/assets/js/pages/tracking-coletas-resumo.init.js
@@ -155,7 +155,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const habilitado = !!(dataInicio && dataFim && (temDados || podeReajustar));
     btnGerarFechamento.disabled = !habilitado;
     if (wrapBtnGerarFechamento) {
-      wrapBtnGerarFechamento.title = !habilitado ? (!temDados && !podeReajustar ? "Não há dados para gerar fechamento" : "Preencha o período") : (podeReajustar ? (basesReajuste.length > 1 ? "Reajustar: selecione a base" : "Reajustar fechamento") : "Gerar fechamento");
+      wrapBtnGerarFechamento.title = !habilitado ? (!temDados && !podeReajustar ? "Não há dados para gerar fechamento" : "Preencha o período") : (podeReajustar ? (basesReajuste.length > 1 ? (typeof window.ownerTerm === "function" ? window.ownerTerm("reajustar_selecione") : "Reajustar: selecione a base") : "Reajustar fechamento") : "Gerar fechamento");
     }
     btnGerarFechamento.innerHTML = podeReajustar ? '<i class="ri-edit-line me-1"></i> Reajustar' : '<i class="ri-file-add-line me-1"></i> Gerar Fechamento';
   }
@@ -536,15 +536,15 @@ async function carregarResumoCompleto() {
     if (basesReajuste.length > 1) {
       const opcoes = basesReajuste.reduce((acc, b) => { acc[b.base] = b.base; return acc; }, {});
       const result = window.Swal ? await Swal.fire({
-        title: "Selecione a base",
-        html: "Há mais de uma base com fechamento GERADO. Escolha qual deseja reajustar.",
+        title: typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_a_base") : "Selecione a base",
+        html: typeof window.ownerTerm === "function" ? window.ownerTerm("ha_mais_de_uma_base") : "Há mais de uma base com fechamento GERADO. Escolha qual deseja reajustar.",
         showCancelButton: true,
         cancelButtonText: "Cancelar",
         confirmButtonText: "Reajustar",
         input: "select",
         inputOptions: opcoes,
-        inputPlaceholder: "Selecione a base",
-        inputValidator: (v) => (!v ? "Selecione uma base" : null),
+        inputPlaceholder: typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_a_base") : "Selecione a base",
+        inputValidator: (v) => (!v ? (typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_uma_base_validator") : "Selecione uma base") : null),
       }) : null;
       const selecionado = result?.value;
       if (selecionado) {
@@ -575,7 +575,7 @@ async function carregarResumoCompleto() {
       });
     } catch (err) {
       console.error("Erro ao carregar bases:", err);
-      if (window.Swal) Swal.fire({ icon: "error", title: "Erro", text: "Erro ao carregar bases." });
+      if (window.Swal) Swal.fire({ icon: "error", title: "Erro", text: typeof window.ownerTerm === "function" ? window.ownerTerm("erro_carregar_bases") : "Erro ao carregar bases." });
       return;
     }
     const modal = new bootstrap.Modal(qs("#modalSelecionarBaseFechamento"));
@@ -586,7 +586,7 @@ async function carregarResumoCompleto() {
     const sel = document.getElementById("modalSelecionarBaseFechamentoSelect");
     const base = (sel?.value || "").trim();
     if (!base) {
-      if (window.Swal) Swal.fire({ icon: "warning", title: "Atenção", text: "Selecione uma base." });
+      if (window.Swal) Swal.fire({ icon: "warning", title: "Atenção", text: typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_uma_base_toast") : "Selecione uma base." });
       return;
     }
     const modalStep1 = bootstrap.Modal.getInstance(qs("#modalSelecionarBaseFechamento"));
@@ -619,14 +619,14 @@ async function carregarResumoCompleto() {
             const result = await Swal.fire({
               icon: "question",
               title: "Fechamento já existente",
-              text: "Já existe um fechamento gerado para esta base e período. Deseja reajustar?",
+              text: typeof window.ownerTerm === "function" ? window.ownerTerm("ja_existe_fechamento") : "Já existe um fechamento gerado para esta base e período. Deseja reajustar?",
               showCancelButton: true,
               confirmButtonText: "Sim, reajustar",
               cancelButtonText: "Cancelar"
             });
             confirmado = !!result?.isConfirmed;
           } else {
-            confirmado = confirm("Já existe um fechamento gerado para esta base e período. Deseja reajustar?");
+            confirmado = confirm(typeof window.ownerTerm === "function" ? window.ownerTerm("ja_existe_fechamento") : "Já existe um fechamento gerado para esta base e período. Deseja reajustar?");
           }
           acao = confirmado ? "reajustar" : "cancelar";
           if (confirmado) {
@@ -648,7 +648,7 @@ async function carregarResumoCompleto() {
     const ctx = state.contextoFechamento;
     const base = baseOverride ?? (modoEdicao && ctx?.base ? ctx.base : null) ?? (fltBase.value || "").trim();
     if (!base) {
-      if (window.Swal) Swal.fire({ icon: "warning", title: "Atenção", text: "É necessário informar a base." });
+      if (window.Swal) Swal.fire({ icon: "warning", title: "Atenção", text: typeof window.ownerTerm === "function" ? window.ownerTerm("informe_a_base") : "É necessário informar a base." });
       return;
     }
     const periodoInicio = fltFrom.value;
@@ -658,10 +658,10 @@ async function carregarResumoCompleto() {
     const titleEl = document.getElementById("modalFechamentoBasesLabel");
     const btnModal = document.getElementById("btnGerarFechamentoModal");
     if (modoEdicao && idFech) {
-      if (titleEl) titleEl.innerHTML = '<i class="ri-building-line me-2"></i>Reajustar Fechamento de Base';
+      if (titleEl) titleEl.innerHTML = '<i class="ri-building-line me-2"></i>' + (typeof window.ownerTerm === "function" ? window.ownerTerm("reajustar_fechamento_base") : "Reajustar Fechamento de Base");
       if (btnModal) btnModal.innerHTML = '<i class="ri-save-line me-1"></i> Salvar Reajuste';
     } else {
-      if (titleEl) titleEl.innerHTML = '<i class="ri-building-line me-2"></i>Gerar Fechamento de Base';
+      if (titleEl) titleEl.innerHTML = '<i class="ri-building-line me-2"></i>' + (typeof window.ownerTerm === "function" ? window.ownerTerm("gerar_fechamento_base") : "Gerar Fechamento de Base");
       if (btnModal) btnModal.innerHTML = '<i class="ri-file-add-line me-1"></i> Gerar Fechamento';
     }
 
@@ -1423,7 +1423,7 @@ async function carregarResumoCompleto() {
     const g_avulso = chkGavulso?.checked ? (parseInt(inputGavulso?.value, 10) || 1) : 0;
 
     if (!base) {
-      Swal.fire({ icon: "warning", title: "Campo obrigatório", text: "Selecione uma base." });
+      Swal.fire({ icon: "warning", title: "Campo obrigatório", text: typeof window.ownerTerm === "function" ? window.ownerTerm("selecione_uma_base_toast") : "Selecione uma base." });
       return;
     }
 
@@ -1453,7 +1453,7 @@ async function carregarResumoCompleto() {
           const err = await res.json().catch(() => ({}));
           const msg = Array.isArray(err?.detail) ? (err.detail[0]?.msg || err.detail[0]) : (err?.detail || res.statusText);
           if (res.status === 409) {
-            Swal.fire({ icon: "warning", title: "Lançamento já existente", text: msg || "Já existe um lançamento para essa mesma data e base. Use Editar no registro existente." });
+            Swal.fire({ icon: "warning", title: "Lançamento já existente", text: msg || (typeof window.ownerTerm === "function" ? window.ownerTerm("lancamento_mesma_data_base") : "Já existe um lançamento para essa mesma data e base. Use Editar no registro existente.") });
             return;
           }
           throw new Error(msg || "Erro ao criar");

--- a/Master/src/assets/js/pages/tracking-contabilidade.init.js
+++ b/Master/src/assets/js/pages/tracking-contabilidade.init.js
@@ -258,7 +258,7 @@ document.addEventListener("DOMContentLoaded", () => {
       if (listaRent) {
         listaRent.innerHTML =
           rentabilidade.length === 0
-            ? "<p class=\"text-muted small mb-0\">Nenhuma base no período.</p>"
+            ? "<p class=\"text-muted small mb-0\">" + (typeof window.ownerTerm === "function" ? window.ownerTerm("nenhuma_base_periodo") : "Nenhuma base no período.") + "</p>"
             : rentabilidade
                 .map(
                   (r, i) => `

--- a/Master/src/assets/js/pages/tracking-registros.init.js
+++ b/Master/src/assets/js/pages/tracking-registros.init.js
@@ -2057,7 +2057,7 @@ function setupPagerEvents() {
       if (!isEditChanged()) return notify("Nenhuma alteração para salvar.", "info");
 
       if (eSta?.value === "Não Coletado" && eBase && !eBase.value)
-        return notify("Base obrigatória para 'Não Coletado'.", "warning");
+        return notify(typeof window.ownerTerm === "function" ? window.ownerTerm("base_obrigatoria_nao_coletado") : "Base obrigatória para 'Não Coletado'.", "warning");
 
       function mapStatusToApi(v){
         return (
@@ -2099,7 +2099,7 @@ function setupPagerEvents() {
       if ((eMotoboy?.value || "") !== editInitialState.motoboy) camposAlterados.push("Motoboy");
       if ((eSta?.value || "") !== editInitialState.status) camposAlterados.push("Status");
       if ((eSrv?.value || "") !== editInitialState.servico) camposAlterados.push("Serviço");
-      if ((eBase?.value || "") !== editInitialState.base) camposAlterados.push("Base");
+      if ((eBase?.value || "") !== editInitialState.base) camposAlterados.push(typeof window.ownerTerm === "function" ? window.ownerTerm("base") : "Base");
 
       var confirmMsg = "Campos alterados: " + (camposAlterados.length ? camposAlterados.join(", ") : "nenhum");
       var confirmTitle = "Confirmar alterações";
@@ -2328,7 +2328,7 @@ function setupPagerEvents() {
       if (bulkMotoboy?.value) campos.push("Motoboy");
       if (bulkStatus?.value) campos.push("Status");
       if (bulkServico?.value) campos.push("Serviço");
-      if (body.base) campos.push("Base");
+      if (body.base) campos.push(typeof window.ownerTerm === "function" ? window.ownerTerm("base") : "Base");
 
       var bulkConfirmTitle = "Confirmar alterações em lote";
       var bulkConfirmMsg = "Aplicar alterações em " + ids.length + " registros?\nCampos: " + campos.join(", ");

--- a/Master/src/dashboard-coletas.html
+++ b/Master/src/dashboard-coletas.html
@@ -108,10 +108,10 @@
                   <div id="card-bases-ativas-single" class="card card-height-100 border border-info">
                     <div class="card-body d-flex align-items-center">
                       <div class="flex-grow-1">
-                        <p class="text-muted mb-1">Bases Ativas</p>
+                        <p class="text-muted mb-1" data-owner-term="bases_ativas">Bases Ativas</p>
                         <h4 class="mb-0" id="card-bases-single-text">0 ativas • 0 com • 0 sem coletas</h4>
                         <small class="text-muted">No dia</small>
-                        <button type="button" class="btn btn-link btn-sm p-0 mt-1" id="coletas-btn-bases-sem" data-bs-toggle="modal" data-bs-target="#modal-bases-sem-coletas" style="display:none;">Ver bases sem coletas</button>
+                        <button type="button" class="btn btn-link btn-sm p-0 mt-1" id="coletas-btn-bases-sem" data-bs-toggle="modal" data-bs-target="#modal-bases-sem-coletas" style="display:none;" data-owner-term="ver_bases_sem_coletas">Ver bases sem coletas</button>
                       </div>
                       <i class="bx bx-building fs-2 text-info"></i>
                     </div>
@@ -119,10 +119,10 @@
                   <div id="card-bases-ativas-multiday" class="card card-height-100 border border-info d-none">
                     <div class="card-body d-flex align-items-center">
                       <div class="flex-grow-1">
-                        <p class="text-muted mb-1">Bases Ativas</p>
+                        <p class="text-muted mb-1" data-owner-term="bases_ativas">Bases Ativas</p>
                         <h4 class="mb-0"><span id="card-bases-total">0</span> ativas no período</h4>
                         <small class="text-muted">Ver gráfico abaixo</small>
-                        <button type="button" class="btn btn-link btn-sm p-0 mt-1" id="coletas-btn-bases-sem-multiday" data-bs-toggle="modal" data-bs-target="#modal-bases-sem-coletas">Ver bases sem coletas por dia</button>
+                        <button type="button" class="btn btn-link btn-sm p-0 mt-1" id="coletas-btn-bases-sem-multiday" data-bs-toggle="modal" data-bs-target="#modal-bases-sem-coletas" data-owner-term="ver_bases_sem_coletas_dia">Ver bases sem coletas por dia</button>
                       </div>
                       <i class="bx bx-building fs-2 text-info"></i>
                     </div>
@@ -186,7 +186,7 @@
             <section id="painel-bases-por-dia" class="mb-4 d-none">
               <div class="card border border-info">
                 <div class="card-header d-flex align-items-center gap-2">
-                  <h5 class="card-title mb-0">Bases com e sem coletas por dia</h5>
+                  <h5 class="card-title mb-0" data-owner-term="bases_com_sem_coletas">Bases com e sem coletas por dia</h5>
                   <i class="bx bx-info-circle text-muted fs-16" style="cursor:help" data-bs-toggle="tooltip" data-bs-placement="top" title="Quantidade de bases que tiveram e não tiveram coletas em cada dia do período."></i>
                 </div>
                 <div class="card-body">
@@ -200,7 +200,7 @@
               <div class="modal-dialog modal-dialog-scrollable">
                 <div class="modal-content">
                   <div class="modal-header">
-                    <h5 class="modal-title">Bases sem coletas registradas</h5>
+                    <h5 class="modal-title" data-owner-term="bases_sem_coletas">Bases sem coletas registradas</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                   </div>
                   <div class="modal-body" id="modal-bases-sem-coletas-body">
@@ -270,8 +270,8 @@
                 <div class="card">
                   <div class="card-header d-flex align-items-center gap-2">
                     <div>
-                      <h5 class="card-title mb-0">Ranking por Base/Cliente</h5>
-                      <small class="text-muted">Volume de coletas registradas por base</small>
+                      <h5 class="card-title mb-0" data-owner-term="ranking_por_base_cliente">Ranking por Base/Cliente</h5>
+                    <small class="text-muted" data-owner-term="volume_coletas_por_base">Volume de coletas registradas por base</small>
                     </div>
                     <i class="bx bx-info-circle text-muted fs-14" style="cursor:help" data-bs-toggle="tooltip" data-bs-placement="top" title="Bases ordenadas por volume. Percentual = participação no total. Variação vs período anterior."></i>
                   </div>

--- a/Master/src/dashboard-financeiro.html
+++ b/Master/src/dashboard-financeiro.html
@@ -170,7 +170,7 @@
                 <div class="col-lg-4" id="painel-base">
                   <div class="card h-100">
                     <div class="card-header">
-                      <h5 class="card-title mb-0">Ganho por Base</h5>
+                      <h5 class="card-title mb-0" data-owner-term="ganho_por_base">Ganho por Base</h5>
                       <small class="text-muted">Receita por ponto de coleta</small>
                     </div>
                     <div class="card-body">

--- a/Master/src/dashboard-visao-360.html
+++ b/Master/src/dashboard-visao-360.html
@@ -224,7 +224,7 @@
                   <div id="fifo-drilldown" class="mt-3 d-none">
                     <div class="d-flex gap-2 mb-2 flex-wrap">
                       <select id="fifo-filtro-base" class="form-select form-select-sm" style="max-width: 180px;">
-                        <option value="">Todas as bases</option>
+                        <option value="" data-owner-term="todas_as_bases">Todas as bases</option>
                       </select>
                       <select id="fifo-filtro-marketplace" class="form-select form-select-sm" style="max-width: 160px;">
                         <option value="">Todos os marketplaces</option>
@@ -233,7 +233,7 @@
                     <div class="table-responsive">
                       <table class="table table-sm table-bordered">
                         <thead>
-                          <tr><th>Base</th><th>Código</th><th>Marketplace</th><th>Data Coleta</th><th>Dias</th><th>Status</th></tr>
+                          <tr><th data-owner-term="base">Base</th><th>Código</th><th>Marketplace</th><th>Data Coleta</th><th>Dias</th><th>Status</th></tr>
                         </thead>
                         <tbody id="fifo-tabela"></tbody>
                       </table>
@@ -316,7 +316,7 @@
                   <div class="card border border-info shadow-sm">
                     <div class="card-header py-2 d-flex align-items-center gap-2">
                       <div>
-                        <h6 class="card-title mb-0 fs-14 text-muted">Ranking por Base</h6>
+                        <h6 class="card-title mb-0 fs-14 text-muted" data-owner-term="ranking_por_base">Ranking por Base</h6>
                         <small class="text-muted">Distribuição das SAÍDAS por serviço</small>
                       </div>
                       <i class="bx bx-info-circle text-muted fs-14" style="cursor:help" data-bs-toggle="tooltip" data-bs-placement="top" title="Bases ordenadas por volume de saídas. O percentual azul é saídas/coletas. A barra mostra a divisão por marketplace (Shopee, Mercado Livre, Avulso)."></i>

--- a/Master/src/partials/page-title.html
+++ b/Master/src/partials/page-title.html
@@ -15,7 +15,7 @@
             <div class="page-title-right">
                 <ol class="breadcrumb m-0">
                     <li class="breadcrumb-item"><a href="javascript: void(0);">@@pagetitle</a></li>
-                    <li class="breadcrumb-item active">@@title</li>
+                    <li class="breadcrumb-item active">@@if (ownerTerm) {<span data-owner-term="@@ownerTerm">@@title</span>}@@if (!ownerTerm) {@@title}</li>
                 </ol>
             </div>
 

--- a/Master/src/tracking-base.html
+++ b/Master/src/tracking-base.html
@@ -37,7 +37,7 @@
                   </div>
 
                   <div class="search-box w-100">
-                    <input type="text" id="search" class="form-control" placeholder="Buscar por base...">
+                    <input type="text" id="search" class="form-control" data-owner-term="buscar_por_base" placeholder="Buscar por base...">
                     <i class="ri-search-line search-icon"></i>
                   </div>
                 </div>
@@ -63,7 +63,7 @@
                     <div id="empty" class="text-center text-muted py-4 d-none">
                       <lord-icon src="https://cdn.lordicon.com/msoeawqm.json" trigger="loop"
                         colors="primary:#121331,secondary:#08a88a" style="width:60px;height:60px"></lord-icon>
-                      <div class="mt-2">Nenhuma base encontrada.</div>
+                      <div class="mt-2" data-owner-term="nenhuma_base_encontrada">Nenhuma base encontrada.</div>
                     </div>
                   </div>
 
@@ -91,15 +91,15 @@
               </div>
             </div>
 
-            <!-- Detalhe do Seller selecionado -->
+            <!-- Detalhe da Base/Seller selecionado -->
             <div id="seller-detail" class="card mt-3 d-none">
               <div class="card-header d-flex align-items-center justify-content-between bg-primary bg-opacity-10 border-start border-4 border-primary">
-                <span class="fw-semibold">Dados do Seller selecionado</span>
+                <span class="fw-semibold" data-owner-term="dados_da_base_selecionada">Dados da Base selecionada</span>
                 <small class="text-muted" id="seller-detail-nome"></small>
               </div>
               <div class="card-body">
-                <div id="seller-detail-empty" class="text-muted">
-                  Selecione um Seller na lista acima para ver os detalhes de CNPJ e endereço.
+                <div id="seller-detail-empty" class="text-muted" data-owner-term="selecione_detalhe">
+                  Selecione uma Base na lista acima para ver os detalhes de CNPJ e endereço.
                 </div>
                 <div id="seller-detail-content" class="row g-3 d-none">
                   <div class="col-md-6">
@@ -155,7 +155,7 @@
                 <div class="col-12">
                   <label for="base" class="form-label" data-owner-term="nome_da_base">Nome da Base</label>
                   <input type="text" id="base" class="form-control" required />
-                  <div class="invalid-feedback">Informe o nome da base.</div>
+                  <div class="invalid-feedback" data-owner-term="informe_nome_base">Informe o nome da base.</div>
                 </div>
 
                 <div class="col-md-6">
@@ -187,19 +187,19 @@
           </div>
 
           <div class="card mb-3">
-            <div class="card-header bg-light fw-semibold">Dados do Seller / Base</div>
+            <div class="card-header bg-light fw-semibold" data-owner-term="dados_da_base">Dados da Base</div>
             <div class="card-body">
               <div class="row g-3">
                 <div class="col-12">
-                  <label for="sellerCnpj" class="form-label">CNPJ do Seller/Base</label>
+                  <label for="sellerCnpj" class="form-label" data-owner-term="cnpj_da_entidade">CNPJ da Base</label>
                   <input type="text" id="sellerCnpj" class="form-control" placeholder="00.000.000/0000-00">
-                  <div class="form-text small">Obrigatório quando o Owner for do tipo Base (Seller).</div>
+                  <div class="form-text small" data-owner-term="cnpj_help_owner_base">Obrigatório quando o Owner for do tipo Base (Seller).</div>
                 </div>
 
                 <div class="col-md-6">
                   <label for="sellerCep" class="form-label">CEP</label>
                   <input type="text" id="sellerCep" class="form-control" placeholder="00000-000" maxlength="9" inputmode="numeric">
-                  <div class="form-text small">Digite o CEP e saia do campo para preencher automaticamente (para Seller/Base obrigatório).</div>
+                  <div class="form-text small" data-owner-term="cep_help_entidade">Digite o CEP e saia do campo para preencher automaticamente (obrigatório para a Base).</div>
                 </div>
 
                 <div class="col-md-6">

--- a/Master/src/tracking-coletas-resumo.html
+++ b/Master/src/tracking-coletas-resumo.html
@@ -287,7 +287,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
           </div>
           <div class="modal-body">
-            <p class="text-muted small mb-3">Selecione a base para gerar o fechamento.</p>
+            <p class="text-muted small mb-3" data-owner-term="selecione_a_base_fechamento">Selecione a base para gerar o fechamento.</p>
             <div class="mb-0">
               <label class="form-label" data-owner-term="base">Base</label>
               <select id="modalSelecionarBaseFechamentoSelect" class="form-select">

--- a/Master/src/tracking-contabilidade.html
+++ b/Master/src/tracking-contabilidade.html
@@ -157,8 +157,8 @@
                       <div class="col-lg-6 mb-4">
                         <div class="card h-100">
                           <div class="card-header">
-                            <h5 class="card-title mb-0"><i class="ri-home-4-line me-2"></i>Rentabilidade por Base</h5>
-                            <span class="small text-muted">Ranking de bases ordenado por lucro líquido</span>
+                            <h5 class="card-title mb-0"><i class="ri-home-4-line me-2"></i><span data-owner-term="rentabilidade_por_base">Rentabilidade por Base</span></h5>
+                            <span class="small text-muted" data-owner-term="ranking_bases_lucro">Ranking de bases ordenado por lucro líquido</span>
                           </div>
                           <div class="card-body">
                             <div id="lista-rentabilidade-base"></div>

--- a/Master/src/tracking-registros.html
+++ b/Master/src/tracking-registros.html
@@ -25,7 +25,7 @@
               <div class="registros-toolbar d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4">
                 <div class="registros-toolbar-left d-flex flex-wrap align-items-center gap-2 flex-grow-1" style="min-width: 0;">
                   <div class="input-group registros-search-wrap" style="flex: 1; max-width: 420px;">
-                    <input id="flt-localizar" class="form-control" placeholder="Buscar por código, entregador ou base..." />
+                    <input id="flt-localizar" class="form-control" data-owner-term="buscar_codigo_entregador_base" placeholder="Buscar por código, entregador ou base..." />
                     <button id="btnScan" class="btn btn-outline-secondary" type="button" title="Escanear código">
                       <i class="ri-camera-line"></i>
                     </button>
@@ -375,7 +375,7 @@
                       <th style="min-width:160px;">Horário da ação</th>
                       <th style="min-width:170px;">Entrada no sistema</th>
                       <th style="min-width:110px;">Executado por</th>
-                      <th style="min-width:110px;">Seller</th>
+                      <th style="min-width:110px;" data-owner-term="base">Base</th>
                       <th class="text-center" style="width:50px" title="Pacote G (Grande)">G</th>
                     </tr>
                   </thead>


### PR DESCRIPTION
## Resumo

Corrige furos de nomenclatura Base/Seller nas telas web, toasts, breadcrumb e PDF de fechamento, conforme o `tipo_owner` (Subbase = Base, Base = Seller).

## Tipo de alteração

- [ ] feature
- [ ] bug
- [x] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Centralizou as labels em `ownerTerm()` (`owner-labels.init.js`) e passou a usá-lo no HTML estático e no JS dinâmico.
- Corrigiu cadastro de bases, registros, coleta, fechamento, dashboards e contabilidade.
- Ajustou o PDF/relatório de fechamento para exibir Base ou Seller.
- Manteve neutros: Avisos da Base, status Na Base/Entrada na base e Sellers conectados (ML/Shopee).

## Como testar

- Logar com usuário de owner **Subbase** e conferir Bases / Fechamento de Bases (sem Seller) em cadastro, registros, coleta, fechamento, dashboards e PDF.
- Logar com usuário de owner **Base** e conferir Sellers / Fechamento Seller nas mesmas telas e no PDF.
- Confirmar que Avisos da Base e o status Na Base não mudam.
- Se o tipo do owner acabou de ser alterado no admin, sair e entrar novamente (o `tipo_owner` vem do login).

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [ ] Altera integração com backend/API
- [ ] Requer configuração adicional
- [ ] Requer atualização em outro repositório

## Checklist

- [ ] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend
