### PR TITLE
feat: avulso automático no fechamento e PIX da base

### DIFF
--- a/Master/src/assets/js/pages/tracking-base.init.js
+++ b/Master/src/assets/js/pages/tracking-base.init.js
@@ -185,9 +185,9 @@ async function apiDelete(id) {
       <tr class="row-selectable" data-id="${id}">
         <td class="text-center"><input class="form-check-input sel-row" type="radio" name="sel-base" value="${id}"></td>
         <td>${b.base || "-"}</td>
-        <td>R$ ${Number(b.ml).toFixed(2).replace(".", ",")}</td>
-        <td>R$ ${Number(b.shopee).toFixed(2).replace(".", ",")}</td>
-        <td>R$ ${Number(b.avulso).toFixed(2).replace(".", ",")}</td>
+        <td class="text-end">R$ ${Number(b.ml).toFixed(2).replace(".", ",")}</td>
+        <td class="text-end">R$ ${Number(b.shopee).toFixed(2).replace(".", ",")}</td>
+        <td class="text-end">R$ ${Number(b.avulso).toFixed(2).replace(".", ",")}</td>
         <td class="text-center"><input type="checkbox" class="form-check-input" ${ativoChecked} disabled></td>
       </tr>
     `;
@@ -213,7 +213,7 @@ async function apiDelete(id) {
   let OWNER_INFO = null;
   let CURRENT_PAGE = 1;
   let PER_PAGE = 10;
-  const offcanvas = new bootstrap.Offcanvas("#oc-form");
+  const formModal = new bootstrap.Modal("#oc-form");
 
   async function carregarOwnerInfo() {
     try {
@@ -231,6 +231,7 @@ async function apiDelete(id) {
       if (el && v != null) el.value = v || "";
     };
     setVal("#sellerCnpj", seller.cnpj ? maskCnpj(seller.cnpj) : "");
+    setVal("#sellerPix", seller.chave_pix || "");
     setVal("#sellerCep", seller.cep ? maskCep(seller.cep) : "");
     setVal("#sellerRua", seller.rua || "");
     setVal("#sellerNumero", seller.numero || "");
@@ -297,6 +298,7 @@ async function apiDelete(id) {
 
     const cnpjFormatado = maskCnpj(seller.cnpj || "");
     setText("#s-cnpj", cnpjFormatado);
+    setText("#s-pix", seller.chave_pix);
     setText("#s-cep", seller.cep);
     setText("#s-endereco", endereco);
     setText("#s-cidade-uf", cidadeUf);
@@ -422,8 +424,30 @@ async function apiDelete(id) {
     qs("#shopee").value = data ? `R$ ${Number(data.shopee).toFixed(2).replace(".", ",")}` : "";
     qs("#avulso").value = data ? `R$ ${Number(data.avulso).toFixed(2).replace(".", ",")}` : "";
     qs("#ativo").checked = data != null ? !!data.ativo : true;
+    if (qs("#sellerPix")) qs("#sellerPix").value = "";
 
-    offcanvas.show();
+    atualizarAjudaCamposSeller();
+    formModal.show();
+  }
+
+  function ownerTipoAtual() {
+    return (OWNER_INFO?.tipo_owner || "subbase").toLowerCase();
+  }
+
+  function atualizarAjudaCamposSeller() {
+    const isSeller = ownerTipoAtual() === "base";
+    const cnpjHelp = qs("#sellerCnpjHelp");
+    const cepHelp = qs("#sellerCepHelp");
+    if (cnpjHelp) {
+      cnpjHelp.textContent = isSeller
+        ? "Obrigatório quando o owner for do tipo Base (Seller)."
+        : "Opcional quando o owner for do tipo Subbase.";
+    }
+    if (cepHelp) {
+      cepHelp.textContent = isSeller
+        ? "Digite o CEP e saia do campo para preencher o endereço. Obrigatório para Base (Seller)."
+        : "Opcional. Digite o CEP e saia do campo para preencher o endereço.";
+    }
   }
 
   function formPayload() {
@@ -441,6 +465,7 @@ async function apiDelete(id) {
   // =======================================================
   document.addEventListener("DOMContentLoaded", async () => {
     await carregarOwnerInfo();
+    atualizarAjudaCamposSeller();
 
     const perPageSelect = qs("#perPage");
     if (perPageSelect) {
@@ -604,7 +629,7 @@ async function apiDelete(id) {
       const payload = formPayload();
 
       // Validação adicional de CNPJ/Endereço do Seller/Base
-      const ownerTipo = (OWNER_INFO?.tipo_owner || "subbase").toLowerCase();
+      const ownerTipo = ownerTipoAtual();
       const cnpjDig = onlyDigits(qs("#sellerCnpj")?.value || "");
       const cepDig = onlyDigits(qs("#sellerCep")?.value || "");
       const rua = (qs("#sellerRua")?.value || "").trim();
@@ -613,6 +638,7 @@ async function apiDelete(id) {
       const cidade = (qs("#sellerCidade")?.value || "").trim();
       const estado = (qs("#sellerEstado")?.value || "").trim();
       const complemento = (qs("#sellerComplemento")?.value || "").trim();
+      const chavePix = (qs("#sellerPix")?.value || "").trim();
 
       const errosSeller = [];
       if (ownerTipo === "base") {
@@ -653,6 +679,7 @@ async function apiDelete(id) {
             bairro: bairro || null,
             cidade: cidade || null,
             estado: estado || null,
+            chave_pix: chavePix || null,
           };
           const rSeller = await fetch(`${API_URL}/owner/${encodeURIComponent(OWNER_INFO.id_owner)}/seller-dados`, {
             method: "PATCH",
@@ -671,7 +698,7 @@ async function apiDelete(id) {
         toast(id
           ? (typeof window.ownerTerm === "function" ? window.ownerTerm("base_atualizada") : "Base atualizada com sucesso.")
           : (typeof window.ownerTerm === "function" ? window.ownerTerm("base_criada") : "Base criada com sucesso."));
-        offcanvas.hide();
+        formModal.hide();
         await listarBases();
       } catch (err) {
         if (err.status === 409) {

--- a/Master/src/assets/js/pages/tracking-coletas-relatorio.js
+++ b/Master/src/assets/js/pages/tracking-coletas-relatorio.js
@@ -447,11 +447,13 @@ async function gerarPdfFechamentoBases(idFechamento) {
     doc.setFontSize(10);
     const nomeEmpresa = (seller && seller.nome_base) ? seller.nome_base : base;
     const cnpjVal = seller && seller.cnpj ? formatarCnpjPdf(seller.cnpj) : null;
+    const pixVal = seller && seller.chave_pix ? String(seller.chave_pix).trim() : null;
     const enderecoVal = (seller && seller.endereco_completo) ? seller.endereco_completo : null;
     let boxTop = startY;
     let contentH = paddingBox;
     contentH += lineH;
     if (cnpjVal) contentH += lineH;
+    if (pixVal) contentH += lineH;
     if (enderecoVal) {
       const enderecoLines = doc.splitTextToSize(enderecoVal, boxWidth - paddingBox * 2 - 22);
       contentH += lineH * enderecoLines.length;
@@ -471,6 +473,13 @@ async function gerarPdfFechamentoBases(idFechamento) {
       doc.text("CNPJ:", marginLeft + paddingBox, cursorY);
       doc.setFont(undefined, "normal");
       doc.text(cnpjVal, marginLeft + paddingBox + 22, cursorY);
+      cursorY += lineH;
+    }
+    if (pixVal) {
+      doc.setFont(undefined, "bold");
+      doc.text("PIX:", marginLeft + paddingBox, cursorY);
+      doc.setFont(undefined, "normal");
+      doc.text(pixVal, marginLeft + paddingBox + 22, cursorY);
       cursorY += lineH;
     }
     if (enderecoVal) {

--- a/Master/src/assets/js/pages/tracking-coletas-resumo.init.js
+++ b/Master/src/assets/js/pages/tracking-coletas-resumo.init.js
@@ -299,7 +299,7 @@ async function buscarCancelados() {
       const celFech = celulaFechamento(r);
       tbody.innerHTML += `
         <tr>
-          <td>${r.data}</td>
+          <td class="text-nowrap">${r.data}</td>
           <td>${r.base}</td>
           <td>${r.entregadores}</td>
           <td class="text-center">${r.shopee}</td>
@@ -307,8 +307,8 @@ async function buscarCancelados() {
           <td class="text-center">${r.avulso}</td>
           <td class="text-center">${r.pacotes_g ?? 0}</td>
           <td class="text-center text-danger fw-bold">${r.cancelados}</td>
-          <td class="text-center">${formatarMoeda(r.valor_total)}</td>
-          <td class="text-center">${celFech}</td>
+          <td class="text-center text-nowrap">${formatarMoeda(r.valor_total)}</td>
+          <td class="text-center text-nowrap">${celFech}</td>
           ${acoesCell}
         </tr>`;
     });

--- a/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
+++ b/Master/src/assets/js/pages/tracking-entregadores-resumo.init.js
@@ -69,6 +69,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       g_total: 0,
       conferencia_habilitada: false,
       conferencia_por_dia: [],
+      avulso_valor: 0,
     },
     contextoFechamento: null, // { status, id_fechamento, periodo_inicio, periodo_fim, entregador_nome } quando um único entregador
     entregadoresParaReajuste: [], // quando status GERADO sem entregador no filtro: lista de { entregador_id, entregador_nome, id_fechamento, periodo_inicio, periodo_fim }
@@ -224,7 +225,103 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (state.ajustesFechamento.length > 0) return true;
     const valor = parseFloat(qs("#fech-ajuste-valor")?.value || 0) || 0;
     const motivo = (qs("#fech-ajuste-motivo")?.value || "").trim();
-    return valor > 0 || motivo.length > 0;
+    const qtdeAvulso = parseInt(qs("#fech-avulso-qtde")?.value || "0", 10) || 0;
+    return valor > 0 || motivo.length > 0 || qtdeAvulso > 0;
+  }
+
+  function qtdeAvulsoInformada() {
+    const raw = String(qs("#fech-avulso-qtde")?.value || "").trim();
+    if (!raw) return 0;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  }
+
+  function arredondarDinheiro(v) {
+    return Math.round((Number(v) || 0) * 100) / 100;
+  }
+
+  function montarMotivoAvulso(qtde, unitario) {
+    return "Avulsos (" + qtde + " x " + formatarMoeda(unitario) + ")";
+  }
+
+  function atualizarPreviewAvulso() {
+    const unitario = arredondarDinheiro(state.fechModal.avulso_valor);
+    const qtde = qtdeAvulsoInformada();
+    const total = arredondarDinheiro(qtde * unitario);
+    const elUnit = qs("#fech-avulso-unitario");
+    const elTotal = qs("#fech-avulso-total");
+    const elPreview = qs("#fech-avulso-preview");
+    const elMsg = qs("#fech-avulso-msg");
+    const btn = qs("#btnAdicionarAvulso");
+    if (elUnit) elUnit.textContent = formatarMoeda(unitario);
+    if (elTotal) elTotal.textContent = formatarMoeda(total);
+    if (elPreview) {
+      elPreview.textContent = qtde > 0 && unitario > 0
+        ? montarMotivoAvulso(qtde, unitario) + " = " + formatarMoeda(total)
+        : "";
+    }
+    if (elMsg) {
+      if (unitario <= 0) {
+        elMsg.textContent = "Não há preço de avulso configurado para este motoboy.";
+        elMsg.classList.remove("d-none");
+      } else {
+        elMsg.textContent = "";
+        elMsg.classList.add("d-none");
+      }
+    }
+    if (btn) btn.disabled = !(qtde > 0 && unitario > 0 && total > 0);
+  }
+
+  function aplicarPrecoAvulso(valor) {
+    const n = arredondarDinheiro(valor);
+    state.fechModal.avulso_valor = n > 0 ? n : 0;
+    atualizarPreviewAvulso();
+  }
+
+  async function carregarPrecoAvulsoFallback(executorTipo, executorId) {
+    try {
+      const [resGlobal, resIndiv] = await Promise.all([
+        fetch(`${API_ENTREGADORES}/precos/global`, { credentials: "include" }),
+        fetch(`${API_ENTREGADORES}/precos/individuais`, { credentials: "include" }),
+      ]);
+      let unitario = 0;
+      if (resGlobal.ok) {
+        const globalData = await resGlobal.json();
+        unitario = Number(globalData?.avulso_valor || 0);
+      }
+      if (resIndiv.ok) {
+        const indivData = await resIndiv.json();
+        const items = Array.isArray(indivData?.items) ? indivData.items : [];
+        const match = items.find((it) => {
+          if (executorTipo === "m") return Number(it.motoboy_id) === Number(executorId);
+          if (executorTipo === "e") return Number(it.entregador_id) === Number(executorId);
+          return false;
+        });
+        if (match && match.avulso_valor != null && match.avulso_valor !== "") {
+          unitario = Number(match.avulso_valor);
+        }
+      }
+      aplicarPrecoAvulso(unitario);
+    } catch (err) {
+      console.error("Erro ao carregar preço de avulso:", err);
+      aplicarPrecoAvulso(0);
+    }
+  }
+
+  function adicionarAvulsoAjuste() {
+    const unitario = arredondarDinheiro(state.fechModal.avulso_valor);
+    const qtde = qtdeAvulsoInformada();
+    const total = arredondarDinheiro(qtde * unitario);
+    if (!(qtde > 0 && unitario > 0 && total > 0)) return;
+    state.ajustesFechamento.push({
+      tipo: "ADIÇÃO",
+      valor: total,
+      motivo: montarMotivoAvulso(qtde, unitario),
+    });
+    const inp = qs("#fech-avulso-qtde");
+    if (inp) inp.value = "";
+    atualizarPreviewAvulso();
+    renderListaAjustes();
   }
 
   function renderListaAjustes() {
@@ -491,6 +588,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     state.divergenciaValorBase = false;
     state.valorBaseRecalculado = null;
     state.ajustesFechamento = [];
+    let precoAvulsoCarregado = false;
+    aplicarPrecoAvulso(0);
+    const inpAvulsoQtde = qs("#fech-avulso-qtde");
+    if (inpAvulsoQtde) inpAvulsoQtde.value = "";
 
     const titleEl = qs("#modalFechamentoLabel");
     const btnModal = qs("#btnGerarFechamentoModal");
@@ -530,6 +631,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         const data = await res.json();
         state.fechModal.valorBase = Number(data.valor_base || 0);
         qs("#fech-valor-base").value = formatarMoeda(data.valor_base);
+        if (data.avulso_valor != null && data.avulso_valor !== "") {
+          aplicarPrecoAvulso(data.avulso_valor);
+          precoAvulsoCarregado = true;
+        }
         if ((data.valor_adicao || 0) > 0) state.ajustesFechamento.push({ tipo: "ADIÇÃO", valor: data.valor_adicao, motivo: data.motivo_adicao || "" });
         if ((data.valor_subtracao || 0) > 0) state.ajustesFechamento.push({ tipo: "SUBTRAÇÃO", valor: data.valor_subtracao, motivo: data.motivo_subtracao || "" });
         if (data.divergencia_valor_base && data.valor_base_recalculado != null) {
@@ -572,6 +677,10 @@ document.addEventListener("DOMContentLoaded", async () => {
           const data = await res.json();
           state.fechModal.valorBase = Number(data.valor_base || 0);
           qs("#fech-valor-base").value = formatarMoeda(data.valor_base);
+          if (data.avulso_valor != null && data.avulso_valor !== "") {
+            aplicarPrecoAvulso(data.avulso_valor);
+            precoAvulsoCarregado = true;
+          }
           state.fechModal.g_por_servico = data.g_por_servico || { shopee: 0, ml: 0, avulso: 0 };
           state.fechModal.g_total = data.g_total ?? 0;
           state.fechModal.conferencia_habilitada = !!data.conferencia_habilitada;
@@ -651,6 +760,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     qs("#fech-ajuste-valor").value = 0;
     qs("#fech-ajuste-motivo").value = "";
+    if (!precoAvulsoCarregado) {
+      await carregarPrecoAvulsoFallback(executorTipo, executorId);
+    } else {
+      atualizarPreviewAvulso();
+    }
     atualizarPlaceholderMotivo();
     renderListaAjustes();
     atualizarTotaisModal();
@@ -861,6 +975,14 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   qs("#fech-ajuste-tipo")?.addEventListener("change", atualizarPlaceholderMotivo);
+  qs("#fech-avulso-qtde")?.addEventListener("input", atualizarPreviewAvulso);
+  qs("#fech-avulso-qtde")?.addEventListener("keydown", (ev) => {
+    if (ev.key === "Enter") {
+      ev.preventDefault();
+      adicionarAvulsoAjuste();
+    }
+  });
+  qs("#btnAdicionarAvulso")?.addEventListener("click", adicionarAvulsoAjuste);
   qs("#btnAdicionarAjuste")?.addEventListener("click", () => {
     const tipo = qs("#fech-ajuste-tipo")?.value || "ADIÇÃO";
     const valor = Math.abs(parseFloat(qs("#fech-ajuste-valor")?.value || 0) || 0);

--- a/Master/src/assets/scss/custom.scss
+++ b/Master/src/assets/scss/custom.scss
@@ -1043,3 +1043,28 @@
   }
 }
 
+#coletas-resumo-table {
+  width: 100%;
+}
+#coletas-resumo-table th,
+#coletas-resumo-table td {
+  vertical-align: middle;
+}
+#coletas-resumo-table th:nth-child(-n+3),
+#coletas-resumo-table td:nth-child(-n+3) {
+  text-align: left;
+}
+#tbl-bases {
+  width: 100%;
+}
+#tbl-bases th,
+#tbl-bases td {
+  vertical-align: middle;
+}
+.bases-table-wrap,
+.coletas-resumo-table-wrap {
+  border: 1px solid var(--bs-border-color, #e9ebec);
+  border-radius: 0.4rem;
+  overflow-x: auto;
+}
+

--- a/Master/src/tracking-base.html
+++ b/Master/src/tracking-base.html
@@ -44,17 +44,16 @@
               </div>
 
               <div class="card-body">
-                <div class="bases-table-wrap" style="max-height: calc(100vh - 320px); overflow-y: auto;">
-                  <div class="table-responsive table-card">
-                    <table class="table align-middle table-nowrap" id="tbl-bases">
+                <div class="table-responsive table-card bases-table-wrap">
+                    <table class="table align-middle table-nowrap mb-0" id="tbl-bases">
                       <thead class="table-light">
                         <tr>
-                          <th style="width:56px;">Sel.</th>
+                          <th class="text-center" style="width:56px;">Sel.</th>
                           <th data-owner-term="base">Base</th>
-                          <th>Flex</th>
-                          <th>Shopee</th>
-                          <th>Avulso</th>
-                          <th style="width:110px;">Ativo</th>
+                          <th class="text-end">Flex</th>
+                          <th class="text-end">Shopee</th>
+                          <th class="text-end">Avulso</th>
+                          <th class="text-center" style="width:110px;">Ativo</th>
                         </tr>
                       </thead>
                       <tbody id="tbody-bases"></tbody>
@@ -87,34 +86,37 @@
                       <small id="page-info" class="text-muted"></small>
                     </div>
                   </div>
-                </div>
               </div>
             </div>
 
             <!-- Detalhe da Base/Seller selecionado -->
             <div id="seller-detail" class="card mt-3 d-none">
-              <div class="card-header d-flex align-items-center justify-content-between bg-primary bg-opacity-10 border-start border-4 border-primary">
+              <div class="card-header d-flex align-items-center justify-content-between">
                 <span class="fw-semibold" data-owner-term="dados_da_base_selecionada">Dados da Base selecionada</span>
                 <small class="text-muted" id="seller-detail-nome"></small>
               </div>
               <div class="card-body">
                 <div id="seller-detail-empty" class="text-muted" data-owner-term="selecione_detalhe">
-                  Selecione uma Base na lista acima para ver os detalhes de CNPJ e endereço.
+                  Selecione uma Base na lista acima para ver os detalhes de CNPJ, endereço e PIX.
                 </div>
                 <div id="seller-detail-content" class="row g-3 d-none">
-                  <div class="col-md-6">
+                  <div class="col-md-4">
                     <label class="form-label text-primary fw-medium mb-1">CNPJ</label>
                     <div id="s-cnpj">—</div>
                   </div>
-                  <div class="col-md-6">
+                  <div class="col-md-4">
+                    <label class="form-label text-primary fw-medium mb-1">PIX</label>
+                    <div id="s-pix">—</div>
+                  </div>
+                  <div class="col-md-4">
                     <label class="form-label text-primary fw-medium mb-1">CEP</label>
                     <div id="s-cep">—</div>
                   </div>
-                  <div class="col-12">
+                  <div class="col-md-8">
                     <label class="form-label text-primary fw-medium mb-1">Endereço</label>
                     <div id="s-endereco">—</div>
                   </div>
-                  <div class="col-md-6 offset-md-6">
+                  <div class="col-md-4">
                     <label class="form-label text-primary fw-medium mb-1">Cidade / UF</label>
                     <div id="s-cidade-uf">—</div>
                   </div>
@@ -131,116 +133,140 @@
     @@include("partials/customizer.html")
     @@include("partials/vendor-scripts.html")
 
-    <!-- Offcanvas: Formulário -->
-    <div class="offcanvas offcanvas-end offcanvas-form offcanvas-form--w480"
-         tabindex="-1"
-         id="oc-form"
-         aria-labelledby="ocLabel"
-         style="display:flex; flex-direction:column;"
-         data-bs-scroll="false"
-         data-bs-backdrop="true">
-      <div class="offcanvas-header border-bottom">
-        <h5 class="offcanvas-title" id="ocLabel" data-owner-term="nova_base">Nova Base</h5>
-        <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas"></button>
-      </div>
+    <!-- Modal: Formulário da Base -->
+    <div class="modal fade" id="oc-form" tabindex="-1" aria-labelledby="ocLabel" aria-hidden="true">
+      <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="ocLabel" data-owner-term="nova_base">Nova Base</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <form id="formBase" class="needs-validation" novalidate>
+            <div class="modal-body">
+              <input type="hidden" id="baseId" />
 
-      <form id="formBase" class="needs-validation flex-grow-1 d-flex flex-column overflow-hidden" novalidate>
-        <div class="offcanvas-body overflow-auto flex-grow-1">
-          <input type="hidden" id="baseId" />
-
-          <div class="card mb-3">
-            <div class="card-header bg-light fw-semibold" data-owner-term="dados_da_base">Dados da Base</div>
-            <div class="card-body">
               <div class="row g-3">
+                <div class="col-lg-6">
+                  <div class="card h-100 mb-0">
+                    <div class="card-header bg-light fw-semibold" data-owner-term="dados_da_base">Dados da Base</div>
+                    <div class="card-body">
+                      <div class="row g-3">
+                        <div class="col-12">
+                          <label for="base" class="form-label" data-owner-term="nome_da_base">Nome da Base</label>
+                          <input type="text" id="base" class="form-control" required />
+                          <div class="invalid-feedback" data-owner-term="informe_nome_base">Informe o nome da base.</div>
+                        </div>
+                        <div class="col-md-6">
+                          <label for="flex" class="form-label">Flex</label>
+                          <input type="text" id="flex" class="form-control moeda" placeholder="R$ 0,00" required />
+                          <div class="invalid-feedback">Informe o valor Flex.</div>
+                        </div>
+                        <div class="col-md-6">
+                          <label for="shopee" class="form-label">Shopee</label>
+                          <input type="text" id="shopee" class="form-control moeda" placeholder="R$ 0,00" required />
+                          <div class="invalid-feedback">Informe o valor Shopee.</div>
+                        </div>
+                        <div class="col-md-6">
+                          <label for="avulso" class="form-label">Avulso</label>
+                          <input type="text" id="avulso" class="form-control moeda" placeholder="R$ 0,00" required />
+                          <div class="invalid-feedback">Informe o valor Avulso.</div>
+                        </div>
+                        <div class="col-md-6 d-flex align-items-end">
+                          <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="ativo" checked>
+                            <label class="form-check-label" for="ativo">Ativa</label>
+                          </div>
+                        </div>
+                        <div class="col-12">
+                          <label for="sellerPix" class="form-label">PIX para pagamento</label>
+                          <input type="text" id="sellerPix" class="form-control" placeholder="Chave PIX da operação" maxlength="140" autocomplete="off">
+                          <div class="form-text small">Opcional. É a chave que a base usa para pagar o fechamento. Aparece no comprovante.</div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="col-lg-6">
+                  <div class="card h-100 mb-0">
+                    <div class="card-header bg-light fw-semibold">CNPJ e endereço</div>
+                    <div class="card-body">
+                      <div class="row g-3">
+                        <div class="col-md-6">
+                          <label for="sellerCnpj" class="form-label" data-owner-term="cnpj_da_entidade">CNPJ da Base</label>
+                          <input type="text" id="sellerCnpj" class="form-control" placeholder="00.000.000/0000-00">
+                          <div class="form-text small" id="sellerCnpjHelp">Opcional quando o owner for do tipo Subbase.</div>
+                        </div>
+                        <div class="col-md-6">
+                          <label for="sellerCep" class="form-label">CEP</label>
+                          <input type="text" id="sellerCep" class="form-control" placeholder="00000-000" maxlength="9" inputmode="numeric">
+                          <div class="form-text small" id="sellerCepHelp">Digite o CEP e saia do campo para preencher o endereço.</div>
+                        </div>
+                        <div class="col-md-8">
+                          <label for="sellerRua" class="form-label">Rua</label>
+                          <input type="text" id="sellerRua" class="form-control" placeholder="Nome da rua">
+                        </div>
+                        <div class="col-md-4">
+                          <label for="sellerNumero" class="form-label">Número</label>
+                          <input type="text" id="sellerNumero" class="form-control" placeholder="123">
+                        </div>
+                        <div class="col-12">
+                          <label for="sellerComplemento" class="form-label">Complemento</label>
+                          <input type="text" id="sellerComplemento" class="form-control" placeholder="Apto, sala, bloco...">
+                        </div>
+                        <div class="col-md-5">
+                          <label for="sellerBairro" class="form-label">Bairro</label>
+                          <input type="text" id="sellerBairro" class="form-control" placeholder="Ex: Centro">
+                        </div>
+                        <div class="col-md-5">
+                          <label for="sellerCidade" class="form-label">Cidade</label>
+                          <input type="text" id="sellerCidade" class="form-control" placeholder="Ex: São Paulo">
+                        </div>
+                        <div class="col-md-2">
+                          <label for="sellerEstado" class="form-label">UF</label>
+                          <input type="text" id="sellerEstado" class="form-control" maxlength="2" placeholder="UF">
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
                 <div class="col-12">
-                  <label for="base" class="form-label" data-owner-term="nome_da_base">Nome da Base</label>
-                  <input type="text" id="base" class="form-control" required />
-                  <div class="invalid-feedback" data-owner-term="informe_nome_base">Informe o nome da base.</div>
-                </div>
-
-                <div class="col-md-6">
-                  <label for="flex" class="form-label">Flex</label>
-                  <input type="text" id="flex" class="form-control moeda" placeholder="R$ 0,00" required />
-                  <div class="invalid-feedback">Informe o valor Flex.</div>
-                </div>
-
-                <div class="col-md-6">
-                  <label for="shopee" class="form-label">Shopee</label>
-                  <input type="text" id="shopee" class="form-control moeda" placeholder="R$ 0,00" required />
-                  <div class="invalid-feedback">Informe o valor Shopee.</div>
-                </div>
-
-                <div class="col-md-6">
-                  <label for="avulso" class="form-label">Avulso</label>
-                  <input type="text" id="avulso" class="form-control moeda" placeholder="R$ 0,00" required />
-                  <div class="invalid-feedback">Informe o valor Avulso.</div>
-                </div>
-
-                <div class="col-md-6 d-flex align-items-end">
-                  <div class="form-check form-switch">
-                    <input class="form-check-input" type="checkbox" id="ativo" checked>
-                    <label class="form-check-label" for="ativo">Ativo</label>
+                  <div class="card mb-0 d-none" id="agendaColetaCard">
+                    <div class="card-header bg-light fw-semibold">Agenda de coleta</div>
+                    <div class="card-body">
+                      <label for="agendaPreset" class="form-label">Frequência</label>
+                      <select id="agendaPreset" class="form-select mb-3">
+                        <option value="1,2,3,4,5">Segunda a sexta</option>
+                        <option value="1,2,3,4,5,6" selected>Segunda a sábado</option>
+                        <option value="custom">Personalizada</option>
+                      </select>
+                      <div class="d-flex flex-wrap gap-3 mb-3" id="diasColeta">
+                        <label class="form-check"><input class="form-check-input dia-coleta" type="checkbox" value="1"> Seg</label>
+                        <label class="form-check"><input class="form-check-input dia-coleta" type="checkbox" value="2"> Ter</label>
+                        <label class="form-check"><input class="form-check-input dia-coleta" type="checkbox" value="3"> Qua</label>
+                        <label class="form-check"><input class="form-check-input dia-coleta" type="checkbox" value="4"> Qui</label>
+                        <label class="form-check"><input class="form-check-input dia-coleta" type="checkbox" value="5"> Sex</label>
+                        <label class="form-check"><input class="form-check-input dia-coleta" type="checkbox" value="6"> Sáb</label>
+                        <label class="form-check"><input class="form-check-input dia-coleta" type="checkbox" value="7"> Dom</label>
+                      </div>
+                      <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="agendaConfirmada">
+                        <label class="form-check-label" for="agendaConfirmada">Agenda revisada e confirmada</label>
+                      </div>
+                      <div class="form-text">Após confirmar, dias sem lançamento poderão bloquear o fechamento.</div>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-
-          <div class="card mb-3">
-            <div class="card-header bg-light fw-semibold" data-owner-term="dados_da_base">Dados da Base</div>
-            <div class="card-body">
-              <div class="row g-3">
-                <div class="col-12">
-                  <label for="sellerCnpj" class="form-label" data-owner-term="cnpj_da_entidade">CNPJ da Base</label>
-                  <input type="text" id="sellerCnpj" class="form-control" placeholder="00.000.000/0000-00">
-                  <div class="form-text small" data-owner-term="cnpj_help_owner_base">Obrigatório quando o Owner for do tipo Base (Seller).</div>
-                </div>
-
-                <div class="col-md-6">
-                  <label for="sellerCep" class="form-label">CEP</label>
-                  <input type="text" id="sellerCep" class="form-control" placeholder="00000-000" maxlength="9" inputmode="numeric">
-                  <div class="form-text small" data-owner-term="cep_help_entidade">Digite o CEP e saia do campo para preencher automaticamente (obrigatório para a Base).</div>
-                </div>
-
-                <div class="col-md-6">
-                  <label for="sellerRua" class="form-label">Rua</label>
-                  <input type="text" id="sellerRua" class="form-control" placeholder="Nome da rua">
-                </div>
-
-                <div class="col-md-4">
-                  <label for="sellerNumero" class="form-label">Número</label>
-                  <input type="text" id="sellerNumero" class="form-control" placeholder="123">
-                </div>
-
-                <div class="col-md-8">
-                  <label for="sellerComplemento" class="form-label">Complemento</label>
-                  <input type="text" id="sellerComplemento" class="form-control" placeholder="Apto, sala, bloco...">
-                </div>
-
-                <div class="col-md-6">
-                  <label for="sellerBairro" class="form-label">Bairro</label>
-                  <input type="text" id="sellerBairro" class="form-control" placeholder="Ex: Centro">
-                </div>
-
-                <div class="col-md-4">
-                  <label for="sellerCidade" class="form-label">Cidade</label>
-                  <input type="text" id="sellerCidade" class="form-control" placeholder="Ex: São Paulo">
-                </div>
-
-                <div class="col-md-2">
-                  <label for="sellerEstado" class="form-label">Estado</label>
-                  <input type="text" id="sellerEstado" class="form-control" maxlength="2" placeholder="UF">
-                </div>
-              </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-soft-secondary" data-bs-dismiss="modal">Cancelar</button>
+              <button type="submit" class="btn btn-primary" id="btnSalvar">Salvar</button>
             </div>
-          </div>
+          </form>
         </div>
-
-        <div class="offcanvas-footer d-flex justify-content-end gap-2 p-3 border-top bg-body flex-shrink-0">
-          <button type="button" class="btn btn-soft-secondary" data-bs-dismiss="offcanvas">Cancelar</button>
-          <button type="submit" class="btn btn-primary" id="btnSalvar">Salvar</button>
-        </div>
-      </form>
+      </div>
     </div>
 
     <!-- Modal de exclusão -->
@@ -273,7 +299,7 @@
       });
     </script>
 
-    <script src="assets/js/pages/tracking-base.init.js?v=1"></script>
+    <script src="assets/js/pages/tracking-base.init.js?v=2"></script>
     <script src="assets/js/app.js"></script>
   </body>
 </html>

--- a/Master/src/tracking-coletas-resumo.html
+++ b/Master/src/tracking-coletas-resumo.html
@@ -189,8 +189,8 @@
 
 
                 <!-- 🔹 Tabela -->
-<div class="table-responsive table-card">
-  <table id="coletas-resumo-table" class="table table-striped align-middle table-hover">
+<div class="table-responsive table-card coletas-resumo-table-wrap">
+  <table id="coletas-resumo-table" class="table table-striped align-middle table-hover table-nowrap mb-0">
     <thead class="table-light">
       <tr>
         <th>Data</th>

--- a/Master/src/tracking-entregadores-resumo.html
+++ b/Master/src/tracking-entregadores-resumo.html
@@ -223,6 +223,34 @@
               </div>
             </div>
 
+            <div class="mb-3 card border fechamento-ajuste-g-card" id="fech-avulso-card">
+              <div class="card-body py-3">
+                <label class="form-label form-label-modal fw-semibold">Adicionar avulso</label>
+                <p class="small text-muted mb-2">Informe a quantidade. O valor e a justificativa são preenchidos automaticamente com o preço deste motoboy.</p>
+                <div class="row g-2 align-items-end">
+                  <div class="col-md-3">
+                    <label class="form-label form-label-modal small" for="fech-avulso-qtde">Quantidade</label>
+                    <input type="number" id="fech-avulso-qtde" class="form-control form-control-sm" min="1" step="1" inputmode="numeric" placeholder="0">
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label form-label-modal small">Valor unitário</label>
+                    <div class="form-control form-control-sm form-control-readonly" id="fech-avulso-unitario">R$ 0,00</div>
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label form-label-modal small">Total</label>
+                    <div class="form-control form-control-sm form-control-readonly" id="fech-avulso-total">R$ 0,00</div>
+                  </div>
+                  <div class="col-md-3">
+                    <button type="button" id="btnAdicionarAvulso" class="btn btn-outline-primary btn-sm w-100" disabled>
+                      <i class="ri-add-circle-line me-1"></i> Adicionar avulso
+                    </button>
+                  </div>
+                </div>
+                <div id="fech-avulso-preview" class="small text-secondary mt-2"></div>
+                <div id="fech-avulso-msg" class="small text-danger mt-1 d-none"></div>
+              </div>
+            </div>
+
             <div class="mb-3">
               <label class="form-label form-label-modal fw-semibold">Ajustes Manuais</label>
               <div id="fech-lista-ajustes" class="mb-2"></div>
@@ -284,7 +312,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js"></script>
     <script src="assets/js/components/date-picker-dashboard.js"></script>
     <script src="assets/js/pages/tracking-entregadores-fechamento-pdf.js"></script>
-    <script src="assets/js/pages/tracking-entregadores-resumo.init.js?v=3"></script>
+    <script src="assets/js/pages/tracking-entregadores-resumo.init.js?v=4"></script>
     <script src="assets/js/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Resumo

No fechamento do motoboy, adiciona avulso só com a quantidade. No cadastro da base, inclui PIX opcional, modal largo e tabela alinhada no fechamento de bases.

## Tipo de alteração

- [x] feature
- [ ] bug
- [ ] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Modal de gerar/reajustar fechamento do motoboy ganha atalho "Adicionar avulso" por quantidade, com valor e justificativa automáticos.
- Cadastro da base deixa a gaveta estreita e passa a modal largo, com campo PIX opcional por base.
- CNPJ e endereço ficam opcionais quando o owner é Subbase; obrigatórios quando é Base (Seller).
- Comprovante do fechamento de bases passa a exibir o PIX.
- Tabela de Fechamento de Bases e lista de Bases alinhadas.

## Como testar

- Fechamento de Motoboys: abrir preview, informar quantidade de avulso e conferir valor = qtde × preço (exceção ou global) com justificativa `Avulsos (N x R$ ...)`.
- Reajuste de fechamento já gerado: o mesmo atalho deve aparecer.
- Configurações > Bases: abrir cadastro em monitor/notebook e conferir modal em duas colunas.
- Owner Subbase: salvar base só com PIX, sem CNPJ/endereço.
- Gerar fechamento de base e abrir o comprovante: deve aparecer a linha PIX.
- Conferir alinhamento da tabela em Fechamento de Bases.

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

## Checklist

- [ ] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

## Rollback

Reverter o PR. A tela volta ao modal antigo e ao ajuste manual sem atalho de avulso. Depende do backend correspondente já publicado (campos `avulso_valor` e `chave_pix`).


Made with [Cursor](https://cursor.com)