### PR TITLE
feat: exibe entradas e origem da cobrança no indicador admin

### DIFF
--- a/Master/src/assets/js/pages/dashboard-admin.init.js
+++ b/Master/src/assets/js/pages/dashboard-admin.init.js
@@ -89,6 +89,7 @@
   function renderCards(data) {
     const c = data.cards || {};
     setText("card-total-coletas", c.total_coletas ?? 0);
+    setText("card-total-entradas", c.total_entradas ?? 0);
     setText("card-total-saidas", c.total_saidas ?? 0);
     setText("card-receita-admin", formatMoeda(c.receita_admin));
     setText("card-owners-ativos", c.owners_ativos ?? 0);
@@ -104,16 +105,18 @@
     }
     const labels = items.map(function (x) { return x.sub_base || "-"; });
     const coletas = items.map(function (x) { return x.coletas || 0; });
+    const entradas = items.map(function (x) { return x.entradas || 0; });
     const saidas = items.map(function (x) { return x.saidas || 0; });
     var chart = echarts.getInstanceByDom(el);
     if (!chart) chart = echarts.init(el);
     chart.setOption({
       tooltip: { trigger: "axis" },
-      legend: { data: ["Coletas", "Saídas"], bottom: 0 },
+      legend: { data: ["Coletas", "Entradas", "Saídas"], bottom: 0 },
       xAxis: { type: "category", data: labels },
       yAxis: { type: "value" },
       series: [
         { name: "Coletas", type: "bar", data: coletas, itemStyle: { color: "#198754" } },
+        { name: "Entradas", type: "bar", data: entradas, itemStyle: { color: "#0d6efd" } },
         { name: "Saídas", type: "bar", data: saidas, itemStyle: { color: "#dc3545" } }
       ]
     }, true);
@@ -148,22 +151,33 @@
     }).join("");
   }
 
+  function tipoBadgeClass(tipo) {
+    if (tipo === "Só Saída") return "bg-secondary";
+    if (tipo === "Entrada") return "bg-info";
+    if (tipo === "Coleta + Entrada") return "bg-dark";
+    return "bg-primary";
+  }
+
   function renderPerformancePorOwner(data) {
     const items = data.performance_por_owner || [];
     const tbody = document.getElementById("performance-por-owner");
     if (!tbody) return;
     if (items.length === 0) {
-      tbody.innerHTML = "<tr><td colspan='6' class='text-muted text-center py-3'>Sem dados</td></tr>";
+      tbody.innerHTML = "<tr><td colspan='7' class='text-muted text-center py-3'>Sem dados</td></tr>";
       return;
     }
     tbody.innerHTML = items.map(function (r) {
-      var tipoClass = r.tipo === "Só Saída" ? "bg-secondary" : "bg-primary";
+      var detalhe = r.base_cobranca_detalhe ? String(r.base_cobranca_detalhe) : "";
       return "<tr>" +
         "<td><strong>" + escapeHtml(r.sub_base) + "</strong></td>" +
-        "<td><span class='badge " + tipoClass + "'>" + escapeHtml(r.tipo) + "</span></td>" +
+        "<td><span class='badge " + tipoBadgeClass(r.tipo) + "'>" + escapeHtml(r.tipo) + "</span></td>" +
         "<td class='text-end'>" + (r.coletas || 0) + "</td>" +
+        "<td class='text-end'>" + (r.entradas || 0) + "</td>" +
         "<td class='text-end'>" + (r.saidas || 0) + "</td>" +
-        "<td class='text-end'>" + (r.base_cobranca || 0) + " pacotes</td>" +
+        "<td class='text-end'>" +
+          (r.base_cobranca || 0) + " pacotes" +
+          (detalhe && detalhe !== "0 pacotes" ? "<div class='small text-muted'>" + escapeHtml(detalhe) + "</div>" : "") +
+        "</td>" +
         "<td class='text-end text-success'>" + formatMoeda(r.receita_admin) + "</td>" +
         "</tr>";
     }).join("");

--- a/Master/src/dashboard-admin.html
+++ b/Master/src/dashboard-admin.html
@@ -65,8 +65,8 @@
 
             <!-- Cards de topo -->
             <section class="mb-4">
-              <div class="row g-3">
-                <div class="col-6 col-xl-3">
+              <div class="row g-3 row-cols-2 row-cols-xl-5">
+                <div class="col">
                   <div class="card card-height-100 border border-success">
                     <div class="card-body d-flex align-items-center">
                       <div class="flex-grow-1">
@@ -78,7 +78,19 @@
                     </div>
                   </div>
                 </div>
-                <div class="col-6 col-xl-3">
+                <div class="col">
+                  <div class="card card-height-100 border border-primary">
+                    <div class="card-body d-flex align-items-center">
+                      <div class="flex-grow-1">
+                        <p class="text-muted mb-1">Total Entradas</p>
+                        <h4 class="mb-0"><span id="card-total-entradas">0</span></h4>
+                        <small class="text-muted">Entraram no período</small>
+                      </div>
+                      <i class="bx bx-log-in-circle fs-2 text-primary"></i>
+                    </div>
+                  </div>
+                </div>
+                <div class="col">
                   <div class="card card-height-100 border border-danger">
                     <div class="card-body d-flex align-items-center">
                       <div class="flex-grow-1">
@@ -90,19 +102,19 @@
                     </div>
                   </div>
                 </div>
-                <div class="col-6 col-xl-3">
+                <div class="col">
                   <div class="card card-height-100 border border-info">
                     <div class="card-body d-flex align-items-center">
                       <div class="flex-grow-1">
                         <p class="text-muted mb-1">Receita Admin</p>
                         <h4 class="mb-0"><span id="card-receita-admin">R$ 0,00</span></h4>
-                        <small class="text-muted">Valores config owner</small>
+                        <small class="text-muted">Coleta, entrada ou só saída</small>
                       </div>
                       <i class="bx bx-dollar-circle fs-2 text-info"></i>
                     </div>
                   </div>
                 </div>
-                <div class="col-6 col-xl-3">
+                <div class="col">
                   <div class="card card-height-100 border border-secondary">
                     <div class="card-body d-flex align-items-center">
                       <div class="flex-grow-1">
@@ -122,7 +134,7 @@
               <div class="card">
                 <div class="card-header">
                   <h5 class="card-title mb-0">Volume por Owner</h5>
-                  <small class="text-muted">Comparativo de coletas, saídas e receita</small>
+                  <small class="text-muted">Comparativo de coletas, entradas e saídas</small>
                 </div>
                 <div class="card-body">
                   <div id="chart-volume-owner" class="chart-responsive"></div>
@@ -161,6 +173,7 @@
                             <th>Owner</th>
                             <th>Tipo</th>
                             <th class="text-end">Coletas</th>
+                            <th class="text-end">Entradas</th>
                             <th class="text-end">Saídas</th>
                             <th class="text-end">Base Cobrança</th>
                             <th class="text-end text-success">Receita Admin</th>


### PR DESCRIPTION
## Resumo

O Indicador Administrativo passa a mostrar o volume de entradas e a origem da cobrança (coleta, entrada ou só saída), alinhado ao recálculo do backend.

## Tipo de alteração

- [x] feature
- [ ] bug
- [ ] fix
- [ ] chore
- [ ] documentation
- [ ] refactor
- [ ] breaking-change

## O que foi feito

- Inclui o card Total Entradas e a série de entradas no gráfico por owner.
- Adiciona a coluna Entradas e o detalhe da base de cobrança na tabela de performance.
- Atualiza os badges de tipo para Só Saída, Coleta, Entrada e Coleta + Entrada.

## Como testar

- Publicar antes o backend desta mesma branch (`feat/admin-cobranca-entrada`).
- Como admin (role 0), abrir Indicadores → Admin.
- Conferir card de entradas, gráfico com três séries e tabela com origem da cobrança.
- Filtrar owner só saída, owner com entrada e owner coleta + entrada.

## Impacto

- [ ] Sem impacto em produção
- [x] Altera comportamento existente
- [x] Altera layout/interface
- [x] Altera integração com backend/API
- [ ] Requer configuração adicional
- [x] Requer atualização em outro repositório

Depende do PR de `track_saidas` na mesma branch. Deploy: backend primeiro, depois este HTML.

## Checklist

- [ ] Testei localmente
- [x] Revisei possíveis dados sensíveis
- [ ] Atualizei documentação, se necessário
- [x] Conferi se a alteração depende de backend

A UI não foi validada no navegador nesta sessão; a validação visual fica no ambiente após o deploy do backend.


Made with [Cursor](https://cursor.com)